### PR TITLE
Feature/BE-58 : User Profile API 구현

### DIFF
--- a/backend/app/exercise/exercise_model.py
+++ b/backend/app/exercise/exercise_model.py
@@ -12,3 +12,4 @@ class Exercise(Base):
     description = Column(String(250), nullable=True)
 
     records = relationship("ExerciseRecord", back_populates="exercise")
+    goals = relationship("UserExerciseGoal", back_populates="exercise")

--- a/backend/app/users/dto/user_request.py
+++ b/backend/app/users/dto/user_request.py
@@ -1,0 +1,38 @@
+from pydantic import BaseModel, Field
+
+
+class ExerciseGoalCreateRequest(BaseModel):
+    exercise_id: int = Field(
+        ...,
+        description="운동 종목 ID",
+        json_schema_extra={"example": 1},
+    )
+    daily_target_count: int | None = Field(
+        default=None,
+        ge=1,
+        description="일일 목표 횟수",
+        json_schema_extra={"example": 10},
+    )
+    threshold: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=100.0,
+        description="정확도 임계값 (0~100)",
+        json_schema_extra={"example": 80.0},
+    )
+
+
+class ExerciseGoalUpdateRequest(BaseModel):
+    daily_target_count: int | None = Field(
+        default=None,
+        ge=1,
+        description="수정할 일일 목표 횟수",
+        json_schema_extra={"example": 15},
+    )
+    threshold: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=100.0,
+        description="수정할 정확도 임계값 (0~100)",
+        json_schema_extra={"example": 85.0},
+    )

--- a/backend/app/users/dto/user_request.py
+++ b/backend/app/users/dto/user_request.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field
 class ExerciseGoalCreateRequest(BaseModel):
     exercise_id: int = Field(
         ...,
+        ge=1,
         description="운동 종목 ID",
         json_schema_extra={"example": 1},
     )

--- a/backend/app/users/dto/user_request.py
+++ b/backend/app/users/dto/user_request.py
@@ -13,6 +13,12 @@ class ExerciseGoalCreateRequest(BaseModel):
         description="일일 목표 횟수",
         json_schema_extra={"example": 10},
     )
+    daily_target_duration: int | None = Field(
+        default=None,
+        ge=1,
+        description="일일 목표 시간 (초)",
+        json_schema_extra={"example": 60},
+    )
     threshold: float | None = Field(
         default=None,
         ge=0.0,
@@ -28,6 +34,12 @@ class ExerciseGoalUpdateRequest(BaseModel):
         ge=1,
         description="수정할 일일 목표 횟수",
         json_schema_extra={"example": 15},
+    )
+    daily_target_duration: int | None = Field(
+        default=None,
+        ge=1,
+        description="수정할 일일 목표 시간 (초)",
+        json_schema_extra={"example": 90},
     )
     threshold: float | None = Field(
         default=None,

--- a/backend/app/users/dto/user_response.py
+++ b/backend/app/users/dto/user_response.py
@@ -19,6 +19,11 @@ class ExerciseGoalResponse(BaseModel):
         description="일일 목표 횟수",
         json_schema_extra={"example": 10},
     )
+    daily_target_duration: int | None = Field(
+        default=None,
+        description="일일 목표 시간 (초)",
+        json_schema_extra={"example": 60},
+    )
     threshold: float | None = Field(
         default=None,
         description="정확도 임계값 (0~100)",

--- a/backend/app/users/dto/user_response.py
+++ b/backend/app/users/dto/user_response.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ExerciseGoalResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int = Field(
+        ...,
+        description="운동 목표 ID",
+        json_schema_extra={"example": 1},
+    )
+    exercise_id: int = Field(
+        ...,
+        description="운동 종목 ID",
+        json_schema_extra={"example": 1},
+    )
+    daily_target_count: int | None = Field(
+        default=None,
+        description="일일 목표 횟수",
+        json_schema_extra={"example": 10},
+    )
+    threshold: float | None = Field(
+        default=None,
+        description="정확도 임계값 (0~100)",
+        json_schema_extra={"example": 80.0},
+    )

--- a/backend/app/users/models.py
+++ b/backend/app/users/models.py
@@ -1,4 +1,13 @@
-from sqlalchemy import Column, Integer, String, DateTime, Date
+from sqlalchemy import (
+    BigInteger,
+    Column,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    DateTime,
+    Date,
+)
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
@@ -18,3 +27,17 @@ class User(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     exercise_records = relationship("ExerciseRecord", back_populates="user")
+    exercise_goals = relationship("UserExerciseGoal", back_populates="user")
+
+
+class UserExerciseGoal(Base):
+    __tablename__ = "user_exercise_goal"
+
+    id = Column(BigInteger, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("user.id"), nullable=False)
+    exercise_id = Column(BigInteger, ForeignKey("exercises.id"), nullable=False)
+    daily_target_count = Column(Integer, nullable=True)
+    threshold = Column(Float, nullable=True)
+
+    user = relationship("User", back_populates="exercise_goals")
+    exercise = relationship("Exercise", back_populates="goals")

--- a/backend/app/users/models.py
+++ b/backend/app/users/models.py
@@ -37,6 +37,7 @@ class UserExerciseGoal(Base):
     user_id = Column(Integer, ForeignKey("user.id"), nullable=False)
     exercise_id = Column(BigInteger, ForeignKey("exercises.id"), nullable=False)
     daily_target_count = Column(Integer, nullable=True)
+    daily_target_duration = Column(Integer, nullable=True)
     threshold = Column(Float, nullable=True)
 
     user = relationship("User", back_populates="exercise_goals")

--- a/backend/app/users/models.py
+++ b/backend/app/users/models.py
@@ -7,6 +7,7 @@ from sqlalchemy import (
     String,
     DateTime,
     Date,
+    UniqueConstraint,
 )
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
@@ -39,6 +40,8 @@ class UserExerciseGoal(Base):
     daily_target_count = Column(Integer, nullable=True)
     daily_target_duration = Column(Integer, nullable=True)
     threshold = Column(Float, nullable=True)
+
+    __table_args__ = (UniqueConstraint("user_id", "exercise_id"),)
 
     user = relationship("User", back_populates="exercise_goals")
     exercise = relationship("Exercise", back_populates="goals")

--- a/backend/app/users/router.py
+++ b/backend/app/users/router.py
@@ -2,12 +2,32 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
-from app.users.models import User
+from app.exercise.exercise_model import Exercise
+from app.users.models import User, UserExerciseGoal
 from app.users.schemas import BirthDateUpdate, UserResponse, WeeklyTargetUpdate
+from app.users.dto.user_request import (
+    ExerciseGoalCreateRequest,
+    ExerciseGoalUpdateRequest,
+)
+from app.users.dto.user_response import ExerciseGoalResponse
 from app.auth.utils import verify_access_token
 
 
 router = APIRouter(prefix="/api/v1/users", tags=["Users"])
+
+
+@router.get("/me", response_model=UserResponse)
+def get_me(
+    token_data: tuple[str, str] = Depends(verify_access_token),
+    db: Session = Depends(get_db),
+):
+    email, _ = token_data
+    user = db.query(User).filter(User.email == email).first()
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="유저를 찾을 수 없습니다."
+        )
+    return user
 
 
 @router.patch("/me/birth-date", response_model=UserResponse)
@@ -44,3 +64,89 @@ def update_weekly_target(
     db.commit()
     db.refresh(user)
     return user
+
+
+@router.post(
+    "/me/exercise-goals",
+    response_model=ExerciseGoalResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_exercise_goal(
+    data: ExerciseGoalCreateRequest,
+    token_data: tuple[str, str] = Depends(verify_access_token),
+    db: Session = Depends(get_db),
+):
+    email, _ = token_data
+    user = db.query(User).filter(User.email == email).first()
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="유저를 찾을 수 없습니다."
+        )
+    existing = (
+        db.query(UserExerciseGoal)
+        .filter(
+            UserExerciseGoal.user_id == user.id,
+            UserExerciseGoal.exercise_id == data.exercise_id,
+        )
+        .first()
+    )
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="해당 운동 종목의 목표가 이미 존재합니다.",
+        )
+    exercise = db.query(Exercise).filter(Exercise.id == data.exercise_id).first()
+    if not exercise:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="존재하지 않는 운동 종목입니다."
+        )
+    goal = UserExerciseGoal(
+        user_id=user.id,
+        exercise_id=data.exercise_id,
+        daily_target_count=data.daily_target_count,
+        threshold=data.threshold,
+    )
+    db.add(goal)
+    db.commit()
+    db.refresh(goal)
+    return goal
+
+
+@router.patch("/me/exercise-goals/{goal_id}", response_model=ExerciseGoalResponse)
+def update_exercise_goal(
+    goal_id: int,
+    data: ExerciseGoalUpdateRequest,
+    token_data: tuple[str, str] = Depends(verify_access_token),
+    db: Session = Depends(get_db),
+):
+    email, _ = token_data
+    user = db.query(User).filter(User.email == email).first()
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="유저를 찾을 수 없습니다."
+        )
+    goal = (
+        db.query(UserExerciseGoal)
+        .filter(
+            UserExerciseGoal.id == goal_id,
+            UserExerciseGoal.user_id == user.id,
+        )
+        .first()
+    )
+    if not goal:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="운동 목표를 찾을 수 없습니다.",
+        )
+    if data.daily_target_count is None and data.threshold is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="수정할 항목을 하나 이상 입력해주세요.",
+        )
+    if data.daily_target_count is not None:
+        goal.daily_target_count = data.daily_target_count  # type: ignore[assignment]
+    if data.threshold is not None:
+        goal.threshold = data.threshold  # type: ignore[assignment]
+    db.commit()
+    db.refresh(goal)
+    return goal

--- a/backend/app/users/router.py
+++ b/backend/app/users/router.py
@@ -104,6 +104,7 @@ def create_exercise_goal(
         user_id=user.id,
         exercise_id=data.exercise_id,
         daily_target_count=data.daily_target_count,
+        daily_target_duration=data.daily_target_duration,
         threshold=data.threshold,
     )
     db.add(goal)
@@ -138,13 +139,19 @@ def update_exercise_goal(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="운동 목표를 찾을 수 없습니다.",
         )
-    if data.daily_target_count is None and data.threshold is None:
+    if (
+        data.daily_target_count is None
+        and data.daily_target_duration is None
+        and data.threshold is None
+    ):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="수정할 항목을 하나 이상 입력해주세요.",
         )
     if data.daily_target_count is not None:
         goal.daily_target_count = data.daily_target_count  # type: ignore[assignment]
+    if data.daily_target_duration is not None:
+        goal.daily_target_duration = data.daily_target_duration  # type: ignore[assignment]
     if data.threshold is not None:
         goal.threshold = data.threshold  # type: ignore[assignment]
     db.commit()

--- a/backend/app/users/router.py
+++ b/backend/app/users/router.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
@@ -98,7 +99,8 @@ def create_exercise_goal(
     exercise = db.query(Exercise).filter(Exercise.id == data.exercise_id).first()
     if not exercise:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="존재하지 않는 운동 종목입니다."
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="존재하지 않는 운동 종목입니다.",
         )
     goal = UserExerciseGoal(
         user_id=user.id,
@@ -108,7 +110,14 @@ def create_exercise_goal(
         threshold=data.threshold,
     )
     db.add(goal)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="해당 운동 종목의 목표가 이미 존재합니다.",
+        )
     db.refresh(goal)
     return goal
 

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -2,6 +2,7 @@ import pytest
 from fastapi.testclient import TestClient
 from unittest.mock import MagicMock
 from datetime import datetime, timedelta
+from sqlalchemy.exc import IntegrityError
 
 from app.users.models import User, UserExerciseGoal
 from app.exercise.exercise_model import Exercise
@@ -78,7 +79,9 @@ def test_get_me_unauthorized(client):
 
 
 # POST /me/exercise-goals
-def test_create_exercise_goal_success(client, mock_redis_client, access_token, fake_user):
+def test_create_exercise_goal_success(
+    client, mock_redis_client, access_token, fake_user
+):
     test_client, mock_db = client
     mock_redis_client.get.return_value = None
     fake_exercise = Exercise(id=1, name="스쿼트")
@@ -106,7 +109,9 @@ def test_create_exercise_goal_success(client, mock_redis_client, access_token, f
     assert data["threshold"] == 80.0
 
 
-def test_create_exercise_goal_duplicate(client, mock_redis_client, access_token, fake_user):
+def test_create_exercise_goal_duplicate(
+    client, mock_redis_client, access_token, fake_user
+):
     test_client, mock_db = client
     mock_redis_client.get.return_value = None
     fake_goal = UserExerciseGoal(id=1, user_id=1, exercise_id=1)
@@ -161,6 +166,29 @@ def test_create_exercise_goal_exercise_not_found(
     assert response.json()["detail"] == "존재하지 않는 운동 종목입니다."
 
 
+def test_create_exercise_goal_integrity_error(
+    client, mock_redis_client, access_token, fake_user
+):
+    test_client, mock_db = client
+    mock_redis_client.get.return_value = None
+    fake_exercise = Exercise(id=1, name="스쿼트")
+    mock_db.query.return_value.filter.return_value.first.side_effect = [
+        fake_user,
+        None,
+        fake_exercise,
+    ]
+    mock_db.commit.side_effect = IntegrityError(None, None, None)
+
+    response = test_client.post(
+        "/api/v1/users/me/exercise-goals",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={"exercise_id": 1, "daily_target_count": 10},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "해당 운동 종목의 목표가 이미 존재합니다."
+
+
 def test_create_exercise_goal_invalid_count(client, mock_redis_client, access_token):
     test_client, _ = client
     mock_redis_client.get.return_value = None
@@ -175,7 +203,9 @@ def test_create_exercise_goal_invalid_count(client, mock_redis_client, access_to
 
 
 # PATCH /me/exercise-goals/{goal_id}
-def test_update_exercise_goal_success(client, mock_redis_client, access_token, fake_user):
+def test_update_exercise_goal_success(
+    client, mock_redis_client, access_token, fake_user
+):
     test_client, mock_db = client
     mock_redis_client.get.return_value = None
     fake_goal = UserExerciseGoal(
@@ -196,7 +226,9 @@ def test_update_exercise_goal_success(client, mock_redis_client, access_token, f
     assert fake_goal.daily_target_count == 15
 
 
-def test_update_exercise_goal_not_found(client, mock_redis_client, access_token, fake_user):
+def test_update_exercise_goal_not_found(
+    client, mock_redis_client, access_token, fake_user
+):
     test_client, mock_db = client
     mock_redis_client.get.return_value = None
     mock_db.query.return_value.filter.return_value.first.side_effect = [
@@ -214,7 +246,9 @@ def test_update_exercise_goal_not_found(client, mock_redis_client, access_token,
     assert response.json()["detail"] == "운동 목표를 찾을 수 없습니다."
 
 
-def test_update_exercise_goal_no_fields(client, mock_redis_client, access_token, fake_user):
+def test_update_exercise_goal_no_fields(
+    client, mock_redis_client, access_token, fake_user
+):
     test_client, mock_db = client
     mock_redis_client.get.return_value = None
     fake_goal = UserExerciseGoal(
@@ -235,7 +269,9 @@ def test_update_exercise_goal_no_fields(client, mock_redis_client, access_token,
     assert response.json()["detail"] == "수정할 항목을 하나 이상 입력해주세요."
 
 
-def test_update_exercise_goal_invalid_threshold(client, mock_redis_client, access_token):
+def test_update_exercise_goal_invalid_threshold(
+    client, mock_redis_client, access_token
+):
     test_client, _ = client
     mock_redis_client.get.return_value = None
 

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,0 +1,248 @@
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock
+from datetime import datetime, timedelta
+
+from app.users.models import User, UserExerciseGoal
+from app.exercise.exercise_model import Exercise
+from app.auth.utils import create_token
+from app.core.database import get_db
+
+
+@pytest.fixture
+def client(mock_env_vars):
+    from app.main import app
+
+    mock_db = MagicMock()
+    app.dependency_overrides[get_db] = lambda: mock_db
+    yield TestClient(app), mock_db
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def access_token():
+    return create_token(
+        {"sub": "test@test.com", "type": "access"}, timedelta(minutes=30)
+    )
+
+
+@pytest.fixture
+def fake_user():
+    return User(
+        id=1,
+        email="test@test.com",
+        pw="hashed_pw",
+        name="최인규",
+        nickname="짐피티",
+        created_at=datetime(2026, 1, 1, 0, 0, 0),
+    )
+
+
+# GET /me
+def test_get_me_success(client, mock_redis_client, access_token, fake_user):
+    test_client, mock_db = client
+    mock_redis_client.get.return_value = None
+    mock_db.query.return_value.filter.return_value.first.return_value = fake_user
+
+    response = test_client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["email"] == "test@test.com"
+    assert data["nickname"] == "짐피티"
+
+
+def test_get_me_user_not_found(client, mock_redis_client, access_token):
+    test_client, mock_db = client
+    mock_redis_client.get.return_value = None
+    mock_db.query.return_value.filter.return_value.first.return_value = None
+
+    response = test_client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "유저를 찾을 수 없습니다."
+
+
+def test_get_me_unauthorized(client):
+    test_client, _ = client
+
+    response = test_client.get("/api/v1/users/me")
+
+    assert response.status_code == 401
+
+
+# POST /me/exercise-goals
+def test_create_exercise_goal_success(client, mock_redis_client, access_token, fake_user):
+    test_client, mock_db = client
+    mock_redis_client.get.return_value = None
+    fake_exercise = Exercise(id=1, name="스쿼트")
+    mock_db.query.return_value.filter.return_value.first.side_effect = [
+        fake_user,
+        None,
+        fake_exercise,
+    ]
+
+    def mock_refresh(instance):
+        instance.id = 1
+
+    mock_db.refresh.side_effect = mock_refresh
+
+    response = test_client.post(
+        "/api/v1/users/me/exercise-goals",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={"exercise_id": 1, "daily_target_count": 10, "threshold": 80.0},
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["exercise_id"] == 1
+    assert data["daily_target_count"] == 10
+    assert data["threshold"] == 80.0
+
+
+def test_create_exercise_goal_duplicate(client, mock_redis_client, access_token, fake_user):
+    test_client, mock_db = client
+    mock_redis_client.get.return_value = None
+    fake_goal = UserExerciseGoal(id=1, user_id=1, exercise_id=1)
+    mock_db.query.return_value.filter.return_value.first.side_effect = [
+        fake_user,
+        fake_goal,
+    ]
+
+    response = test_client.post(
+        "/api/v1/users/me/exercise-goals",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={"exercise_id": 1},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "해당 운동 종목의 목표가 이미 존재합니다."
+
+
+def test_create_exercise_goal_user_not_found(client, mock_redis_client, access_token):
+    test_client, mock_db = client
+    mock_redis_client.get.return_value = None
+    mock_db.query.return_value.filter.return_value.first.return_value = None
+
+    response = test_client.post(
+        "/api/v1/users/me/exercise-goals",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={"exercise_id": 1},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "유저를 찾을 수 없습니다."
+
+
+def test_create_exercise_goal_exercise_not_found(
+    client, mock_redis_client, access_token, fake_user
+):
+    test_client, mock_db = client
+    mock_redis_client.get.return_value = None
+    mock_db.query.return_value.filter.return_value.first.side_effect = [
+        fake_user,
+        None,  # no existing goal
+        None,  # exercise not found
+    ]
+
+    response = test_client.post(
+        "/api/v1/users/me/exercise-goals",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={"exercise_id": 999},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "존재하지 않는 운동 종목입니다."
+
+
+def test_create_exercise_goal_invalid_count(client, mock_redis_client, access_token):
+    test_client, _ = client
+    mock_redis_client.get.return_value = None
+
+    response = test_client.post(
+        "/api/v1/users/me/exercise-goals",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={"exercise_id": 1, "daily_target_count": 0},
+    )
+
+    assert response.status_code == 422
+
+
+# PATCH /me/exercise-goals/{goal_id}
+def test_update_exercise_goal_success(client, mock_redis_client, access_token, fake_user):
+    test_client, mock_db = client
+    mock_redis_client.get.return_value = None
+    fake_goal = UserExerciseGoal(
+        id=1, user_id=1, exercise_id=1, daily_target_count=10, threshold=80.0
+    )
+    mock_db.query.return_value.filter.return_value.first.side_effect = [
+        fake_user,
+        fake_goal,
+    ]
+
+    response = test_client.patch(
+        "/api/v1/users/me/exercise-goals/1",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={"daily_target_count": 15},
+    )
+
+    assert response.status_code == 200
+    assert fake_goal.daily_target_count == 15
+
+
+def test_update_exercise_goal_not_found(client, mock_redis_client, access_token, fake_user):
+    test_client, mock_db = client
+    mock_redis_client.get.return_value = None
+    mock_db.query.return_value.filter.return_value.first.side_effect = [
+        fake_user,
+        None,
+    ]
+
+    response = test_client.patch(
+        "/api/v1/users/me/exercise-goals/999",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={"daily_target_count": 15},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "운동 목표를 찾을 수 없습니다."
+
+
+def test_update_exercise_goal_no_fields(client, mock_redis_client, access_token, fake_user):
+    test_client, mock_db = client
+    mock_redis_client.get.return_value = None
+    fake_goal = UserExerciseGoal(
+        id=1, user_id=1, exercise_id=1, daily_target_count=10, threshold=80.0
+    )
+    mock_db.query.return_value.filter.return_value.first.side_effect = [
+        fake_user,
+        fake_goal,
+    ]
+
+    response = test_client.patch(
+        "/api/v1/users/me/exercise-goals/1",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "수정할 항목을 하나 이상 입력해주세요."
+
+
+def test_update_exercise_goal_invalid_threshold(client, mock_redis_client, access_token):
+    test_client, _ = client
+    mock_redis_client.get.return_value = None
+
+    response = test_client.patch(
+        "/api/v1/users/me/exercise-goals/1",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={"threshold": 150.0},
+    )
+
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary

> Closes #40 
사용자 정보 조회 및 운동 목표 등록·수정 API 구현했습니다.

## Tasks

- 사용자 정보 조회 API 구현 (GET /api/v1/users/me)
- 운동 목표 등록 API 구현 (POST /api/v1/users/me/exercise-goals)
- 운동 목표 수정 API 구현 (PATCH /api/v1/users/me/exercise-goals/{goal_id})
- 테스트 코드 작성

## To Reviewer

리뷰 부탁드립니다. 수정 사항 말씀해주시면 반영하겠습니다 !


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 운동 목표 관리: 인증된 사용자가 일일 목표(개수·시간)와 임계값을 지정해 운동 목표 생성(201) 및 부분 수정(PATCH) 가능
  * 사용자 프로필 조회: 인증된 사용자 프로필 반환

* **버그 픽스 / 동작 개선**
  * 동일 운동에 대한 중복 생성 차단 및 DB 제약 충돌을 409로 일관 처리
  * 입력 유효성 검증 강화(422)

* **테스트**
  * 프로필 및 운동 목표 관련 통합 테스트 추가(생성/중복/수정/검증/권한)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->