### PR TITLE
Feature/BE-63 : 메인 요약 정보 조회 API 구현

### DIFF
--- a/backend/app/users/dto/user_response.py
+++ b/backend/app/users/dto/user_response.py
@@ -17,10 +17,20 @@ class ExerciseGoalSummaryItem(BaseModel):
         description="일일 목표 횟수",
         json_schema_extra={"example": 10},
     )
+    daily_target_duration: int | None = Field(
+        default=None,
+        description="일일 목표 시간 (초)",
+        json_schema_extra={"example": 60},
+    )
     today_count: int = Field(
         ...,
         description="오늘 완료한 횟수",
         json_schema_extra={"example": 5},
+    )
+    today_duration: int = Field(
+        default=0,
+        description="오늘 완료한 시간 (초)",
+        json_schema_extra={"example": 60},
     )
 
 

--- a/backend/app/users/dto/user_response.py
+++ b/backend/app/users/dto/user_response.py
@@ -1,6 +1,66 @@
 from pydantic import BaseModel, ConfigDict, Field
 
 
+class ExerciseGoalSummaryItem(BaseModel):
+    exercise_id: int = Field(
+        ...,
+        description="운동 종목 ID",
+        json_schema_extra={"example": 1},
+    )
+    exercise_name: str = Field(
+        ...,
+        description="운동 이름",
+        json_schema_extra={"example": "스쿼트"},
+    )
+    daily_target_count: int | None = Field(
+        default=None,
+        description="일일 목표 횟수",
+        json_schema_extra={"example": 10},
+    )
+    today_count: int = Field(
+        ...,
+        description="오늘 완료한 횟수",
+        json_schema_extra={"example": 5},
+    )
+
+
+class MainSummaryResponse(BaseModel):
+    nickname: str = Field(
+        ...,
+        description="사용자 닉네임",
+        json_schema_extra={"example": "짐피티"},
+    )
+    today_achievement_rate: float = Field(
+        ...,
+        description="오늘의 운동 달성률 (0~100)",
+        json_schema_extra={"example": 50.0},
+    )
+    today_completed_count: int = Field(
+        ...,
+        description="오늘 완료한 운동 종류 수",
+        json_schema_extra={"example": 1},
+    )
+    exercise_goals: list[ExerciseGoalSummaryItem] = Field(
+        ...,
+        description="운동 목표 목록 및 오늘 진행 현황",
+    )
+    weekly_workout_days: list[bool] = Field(
+        ...,
+        description="이번 주 운동 여부 (월~일, 7개)",
+        json_schema_extra={"example": [True, False, True, False, False, False, False]},
+    )
+    badges: list[str] = Field(
+        default_factory=list,
+        description="획득한 배지 목록 (추후 연동 예정)",
+        json_schema_extra={"example": []},
+    )
+    ai_comment: str | None = Field(
+        default=None,
+        description="AI PT 코멘트 (추후 연동 예정)",
+        json_schema_extra={"example": None},
+    )
+
+
 class ExerciseGoalResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/users/router.py
+++ b/backend/app/users/router.py
@@ -58,8 +58,8 @@ def get_main_summary(
     today_durations: dict[int, int] = {}
     for record in today_records:
         eid = int(record.exercise_id)
-        today_counts[eid] = today_counts.get(eid, 0) + record.count
-        today_durations[eid] = today_durations.get(eid, 0) + record.duration
+        today_counts[eid] = today_counts.get(eid, 0) + int(record.count)
+        today_durations[eid] = today_durations.get(eid, 0) + int(record.duration)
 
     goals_with_target = [
         g
@@ -78,7 +78,9 @@ def get_main_summary(
             and today_durations.get(int(g.exercise_id), 0) >= g.daily_target_duration
         )
     )
-    achievement_rate = (achieved / len(goals_with_target) * 100) if goals_with_target else 0.0
+    achievement_rate = (
+        (achieved / len(goals_with_target) * 100) if goals_with_target else 0.0
+    )
 
     today_completed_count = len(today_counts)
 
@@ -93,8 +95,10 @@ def get_main_summary(
     exercise_goal_summaries = [
         ExerciseGoalSummaryItem(
             exercise_id=int(goal.exercise_id),
-            exercise_name=exercise_map.get(int(goal.exercise_id), ""),
-            daily_target_count=goal.daily_target_count,
+            exercise_name=str(exercise_map.get(int(goal.exercise_id), "")),
+            daily_target_count=int(goal.daily_target_count)
+            if goal.daily_target_count is not None
+            else None,
             today_count=today_counts.get(int(goal.exercise_id), 0),
         )
         for goal in goals
@@ -106,7 +110,7 @@ def get_main_summary(
     ]
 
     return MainSummaryResponse(
-        nickname=user.nickname,
+        nickname=str(user.nickname),
         today_achievement_rate=round(achievement_rate, 1),
         today_completed_count=today_completed_count,
         exercise_goals=exercise_goal_summaries,

--- a/backend/app/users/router.py
+++ b/backend/app/users/router.py
@@ -99,7 +99,11 @@ def get_main_summary(
             daily_target_count=int(goal.daily_target_count)
             if goal.daily_target_count is not None
             else None,
+            daily_target_duration=int(goal.daily_target_duration)
+            if goal.daily_target_duration is not None
+            else None,
             today_count=today_counts.get(int(goal.exercise_id), 0),
+            today_duration=today_durations.get(int(goal.exercise_id), 0),
         )
         for goal in goals
     ]

--- a/backend/app/users/router.py
+++ b/backend/app/users/router.py
@@ -1,20 +1,117 @@
+from datetime import date, timedelta
+
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
 from app.exercise.exercise_model import Exercise
+from app.exercise_record.exercise_record_model import ExerciseRecord
 from app.users.models import User, UserExerciseGoal
 from app.users.schemas import BirthDateUpdate, UserResponse, WeeklyTargetUpdate
 from app.users.dto.user_request import (
     ExerciseGoalCreateRequest,
     ExerciseGoalUpdateRequest,
 )
-from app.users.dto.user_response import ExerciseGoalResponse
+from app.users.dto.user_response import (
+    ExerciseGoalResponse,
+    ExerciseGoalSummaryItem,
+    MainSummaryResponse,
+)
 from app.auth.utils import verify_access_token
 
 
 router = APIRouter(prefix="/api/v1/users", tags=["Users"])
+
+
+@router.get("/me/summary", response_model=MainSummaryResponse)
+def get_main_summary(
+    token_data: tuple[str, str] = Depends(verify_access_token),
+    db: Session = Depends(get_db),
+):
+    email, _ = token_data
+    user = db.query(User).filter(User.email == email).first()
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="유저를 찾을 수 없습니다."
+        )
+
+    today = date.today()
+    monday = today - timedelta(days=today.weekday())
+
+    goals = db.query(UserExerciseGoal).filter(UserExerciseGoal.user_id == user.id).all()
+
+    week_records = (
+        db.query(ExerciseRecord)
+        .filter(
+            ExerciseRecord.user_id == user.id,
+            func.date(ExerciseRecord.completed_at) >= monday,
+            func.date(ExerciseRecord.completed_at) <= monday + timedelta(days=6),
+        )
+        .all()
+    )
+
+    today_records = [r for r in week_records if r.completed_at.date() == today]
+
+    today_counts: dict[int, int] = {}
+    today_durations: dict[int, int] = {}
+    for record in today_records:
+        eid = int(record.exercise_id)
+        today_counts[eid] = today_counts.get(eid, 0) + record.count
+        today_durations[eid] = today_durations.get(eid, 0) + record.duration
+
+    goals_with_target = [
+        g
+        for g in goals
+        if g.daily_target_count is not None or g.daily_target_duration is not None
+    ]
+    achieved = sum(
+        1
+        for g in goals_with_target
+        if (
+            g.daily_target_count is not None
+            and today_counts.get(int(g.exercise_id), 0) >= g.daily_target_count
+        )
+        or (
+            g.daily_target_duration is not None
+            and today_durations.get(int(g.exercise_id), 0) >= g.daily_target_duration
+        )
+    )
+    achievement_rate = (achieved / len(goals_with_target) * 100) if goals_with_target else 0.0
+
+    today_completed_count = len(today_counts)
+
+    exercise_ids = [int(g.exercise_id) for g in goals]
+    exercises = (
+        db.query(Exercise).filter(Exercise.id.in_(exercise_ids)).all()
+        if exercise_ids
+        else []
+    )
+    exercise_map = {int(e.id): e.name for e in exercises}
+
+    exercise_goal_summaries = [
+        ExerciseGoalSummaryItem(
+            exercise_id=int(goal.exercise_id),
+            exercise_name=exercise_map.get(int(goal.exercise_id), ""),
+            daily_target_count=goal.daily_target_count,
+            today_count=today_counts.get(int(goal.exercise_id), 0),
+        )
+        for goal in goals
+    ]
+
+    worked_days = {r.completed_at.date() for r in week_records}
+    weekly_workout_days = [
+        (monday + timedelta(days=i)) in worked_days for i in range(7)
+    ]
+
+    return MainSummaryResponse(
+        nickname=user.nickname,
+        today_achievement_rate=round(achievement_rate, 1),
+        today_completed_count=today_completed_count,
+        exercise_goals=exercise_goal_summaries,
+        weekly_workout_days=weekly_workout_days,
+    )
 
 
 @router.get("/me", response_model=UserResponse)

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -82,9 +82,53 @@ def test_get_main_summary_success(client, mock_redis_client, access_token, fake_
     assert len(data["exercise_goals"]) == 1
     assert data["exercise_goals"][0]["exercise_name"] == "스쿼트"
     assert data["exercise_goals"][0]["today_count"] == 10
+    assert data["exercise_goals"][0]["today_duration"] == 60
     assert len(data["weekly_workout_days"]) == 7
+    assert data["weekly_workout_days"][today.weekday()] is True
     assert data["badges"] == []
     assert data["ai_comment"] is None
+
+
+def test_get_main_summary_duration_goal(
+    client, mock_redis_client, access_token, fake_user
+):
+    test_client, mock_db = client
+    mock_redis_client.get.return_value = None
+
+    today = date.today()
+    fake_goal = UserExerciseGoal(
+        id=1, user_id=1, exercise_id=2, daily_target_duration=60
+    )
+    fake_exercise = Exercise(id=2, name="플랭크")
+    fake_record = ExerciseRecord(
+        id=1,
+        user_id=1,
+        exercise_id=2,
+        count=0,
+        duration=60,
+        calories=10,
+        score=90,
+        accuracy_avg=85,
+        completed_at=datetime.combine(today, datetime.min.time()),
+    )
+
+    mock_db.query.return_value.filter.return_value.first.side_effect = [fake_user]
+    mock_db.query.return_value.filter.return_value.all.side_effect = [
+        [fake_goal],
+        [fake_record],
+        [fake_exercise],
+    ]
+
+    response = test_client.get(
+        "/api/v1/users/me/summary",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["today_achievement_rate"] == 100.0
+    assert data["exercise_goals"][0]["daily_target_duration"] == 60
+    assert data["exercise_goals"][0]["today_duration"] == 60
 
 
 def test_get_main_summary_no_goals(client, mock_redis_client, access_token, fake_user):

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,11 +1,12 @@
 import pytest
 from fastapi.testclient import TestClient
 from unittest.mock import MagicMock
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from sqlalchemy.exc import IntegrityError
 
 from app.users.models import User, UserExerciseGoal
 from app.exercise.exercise_model import Exercise
+from app.exercise_record.exercise_record_model import ExerciseRecord
 from app.auth.utils import create_token
 from app.core.database import get_db
 
@@ -37,6 +38,90 @@ def fake_user():
         nickname="짐피티",
         created_at=datetime(2026, 1, 1, 0, 0, 0),
     )
+
+
+# GET /me/summary
+def test_get_main_summary_success(client, mock_redis_client, access_token, fake_user):
+    test_client, mock_db = client
+    mock_redis_client.get.return_value = None
+
+    today = date.today()
+    fake_goal = UserExerciseGoal(
+        id=1, user_id=1, exercise_id=1, daily_target_count=10, threshold=80.0
+    )
+    fake_exercise = Exercise(id=1, name="스쿼트")
+    fake_record = ExerciseRecord(
+        id=1,
+        user_id=1,
+        exercise_id=1,
+        count=10,
+        duration=60,
+        calories=50,
+        score=90,
+        accuracy_avg=85,
+        completed_at=datetime.combine(today, datetime.min.time()),
+    )
+
+    mock_db.query.return_value.filter.return_value.first.side_effect = [fake_user]
+    mock_db.query.return_value.filter.return_value.all.side_effect = [
+        [fake_goal],  # goals
+        [fake_record],  # week_records (오늘 포함)
+        [fake_exercise],  # exercises (batch lookup)
+    ]
+
+    response = test_client.get(
+        "/api/v1/users/me/summary",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["nickname"] == "짐피티"
+    assert data["today_achievement_rate"] == 100.0
+    assert data["today_completed_count"] == 1
+    assert len(data["exercise_goals"]) == 1
+    assert data["exercise_goals"][0]["exercise_name"] == "스쿼트"
+    assert data["exercise_goals"][0]["today_count"] == 10
+    assert len(data["weekly_workout_days"]) == 7
+    assert data["badges"] == []
+    assert data["ai_comment"] is None
+
+
+def test_get_main_summary_no_goals(client, mock_redis_client, access_token, fake_user):
+    test_client, mock_db = client
+    mock_redis_client.get.return_value = None
+
+    mock_db.query.return_value.filter.return_value.first.side_effect = [fake_user]
+    mock_db.query.return_value.filter.return_value.all.side_effect = [
+        [],  # no goals
+        [],  # no week_records
+    ]
+
+    response = test_client.get(
+        "/api/v1/users/me/summary",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["today_achievement_rate"] == 0.0
+    assert data["today_completed_count"] == 0
+    assert data["exercise_goals"] == []
+    assert data["weekly_workout_days"] == [False] * 7
+
+
+def test_get_main_summary_user_not_found(client, mock_redis_client, access_token):
+    test_client, mock_db = client
+    mock_redis_client.get.return_value = None
+    mock_db.query.return_value.filter.return_value.first.return_value = None
+
+    response = test_client.get(
+        "/api/v1/users/me/summary",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "유저를 찾을 수 없습니다."
 
 
 # GET /me


### PR DESCRIPTION
## Summary

> Closes #44 
메인 요약 정보 조회 API 구현했습니다.

## Tasks

- 메인 요약 정보 조회 API 구현 (GET /api/v1/users/me/summary)
- 오늘 달성률, 운동 목표 현황, 이번 주 운동 여부 집계
- 테스트 코드 작성

## To Reviewer

리뷰 부탁드립니다. 수정 사항 말씀해주시면 반영하겠습니다 !


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자용 주간 요약 API 추가 — 닉네임, 오늘의 달성률(소수1자리), 오늘 완료된 운동 수, 운동별 목표(횟수/시간) 및 오늘 달성 수, 월~일 7일 간의 운동 여부(7요소), 배지 목록 및 선택적 AI 코멘트 제공
  * 사용자 미존재 시 404 응답 처리

* **테스트**
  * 요약 기능의 성공(횟수/시간 포함)·목표 없음·유저 미존재 경로에 대한 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->