### PR TITLE
Feature/FE-53 : 범위 설정 페이지 및 운동 촬영 페이지 구현

### DIFF
--- a/frontend/src/app/features/workout/CameraAnalysisPage.tsx
+++ b/frontend/src/app/features/workout/CameraAnalysisPage.tsx
@@ -55,7 +55,7 @@ export function CameraAnalysisPage() {
     onPoseLandmarks,
   });
 
-  let noticeMessage = TEXT.searching;
+  let noticeMessage: string = TEXT.searching;
 
   if (!isStreaming) {
     noticeMessage = TEXT.idleFeedback;

--- a/frontend/src/app/features/workout/CameraAnalysisPage.tsx
+++ b/frontend/src/app/features/workout/CameraAnalysisPage.tsx
@@ -1,0 +1,106 @@
+import { useRef } from "react";
+import { useNavigate } from "react-router";
+
+import squatImg from "../../../assets/exercises/squat.png";
+import { CameraStage } from "./components/CameraStage";
+import { WorkoutHeader } from "./components/WorkoutHeader";
+import { useCameraPreview } from "./hooks/useCameraPreview";
+import { usePoseLandmarker } from "./hooks/usePoseLandmarker";
+import { useSquatAnalysis } from "./hooks/useSquatAnalysis";
+import type { ExerciseInfo } from "./types/workoutSession";
+
+const TEXT = {
+  exerciseName: "스쿼트 AI 분석",
+  finishWorkout: "운동 종료",
+  feedbackTitle: "AI 실시간 피드백",
+  idleFeedback: "카메라를 시작하면 실시간 스쿼트 피드백을 제공합니다.",
+  modelLoading: "AI 자세 모델을 불러오는 중입니다...",
+  modelError: "AI 자세 분석을 시작할 수 없습니다.",
+  detecting: "랜드마크를 기반으로 자세를 분석 중입니다.",
+  searching: "화면에서 자세를 찾고 있습니다.",
+} as const;
+
+const DEFAULT_EXERCISE: ExerciseInfo = {
+  id: "squat",
+  name: TEXT.exerciseName,
+  iconSrc: squatImg,
+  targetCount: 10,
+};
+
+export function CameraAnalysisPage() {
+  const navigate = useNavigate();
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  const {
+    cameraStatus,
+    cameraErrorMessage,
+    isStreaming,
+    requestCamera,
+    stopCamera,
+  } = useCameraPreview(videoRef);
+
+  const { analysis, onPoseLandmarks } = useSquatAnalysis({
+    enabled: isStreaming,
+  });
+
+  const {
+    poseStatus,
+    poseErrorMessage,
+    hasPoseLandmarks,
+  } = usePoseLandmarker({
+    enabled: isStreaming,
+    videoRef,
+    canvasRef,
+    onPoseLandmarks,
+  });
+
+  let noticeMessage = TEXT.searching;
+
+  if (!isStreaming) {
+    noticeMessage = TEXT.idleFeedback;
+  } else if (poseStatus === "loading") {
+    noticeMessage = TEXT.modelLoading;
+  } else if (poseStatus === "error") {
+    noticeMessage = poseErrorMessage ?? TEXT.modelError;
+  } else if (hasPoseLandmarks) {
+    noticeMessage = analysis.feedbackMessage || TEXT.detecting;
+  }
+
+  const handleEndWorkout = () => {
+    stopCamera();
+    navigate("/post-workout");
+  };
+
+  return (
+    <div className="flex min-h-[100dvh] items-start justify-center bg-[#080A0D]">
+      <div
+        className="flex w-full max-w-[430px] flex-col px-4 pb-7 pt-3"
+        style={{ minHeight: "100dvh", backgroundColor: "#090B0E" }}
+      >
+        <WorkoutHeader currentCount={analysis.fullRepCount} exercise={DEFAULT_EXERCISE} />
+
+        <main className="mt-4 flex flex-1 flex-col gap-4">
+          <CameraStage
+            canvasRef={canvasRef}
+            cameraErrorMessage={cameraErrorMessage}
+            cameraStatus={cameraStatus}
+            isStreaming={isStreaming}
+            noticeMessage={noticeMessage}
+            noticeTitle={TEXT.feedbackTitle}
+            onRequestCamera={requestCamera}
+            videoRef={videoRef}
+          />
+        </main>
+
+        <button
+          className="mt-5 rounded-[16px] bg-[#3FEED0] py-4 text-[19px] font-extrabold text-[#081B16]"
+          onClick={handleEndWorkout}
+          type="button"
+        >
+          {TEXT.finishWorkout}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/features/workout/MainPage.tsx
+++ b/frontend/src/app/features/workout/MainPage.tsx
@@ -38,10 +38,15 @@ export function MainPage() {
   const { exerciseCounts } = goal;
 
   const handleExerciseClick = (exerciseId: string) => {
+    if (exerciseId !== "squat") {
+      navigate("/workout/camera");
+      return;
+    }
+
     if (calibratedExercises[exerciseId]) {
-      navigate(`/camera/${exerciseId}`);
+      navigate("/workout/camera");
     } else {
-      navigate(`/calibration/${exerciseId}`);
+      navigate(`/workout/calibration/${exerciseId}`);
     }
   };
 

--- a/frontend/src/app/features/workout/PostWorkout.tsx
+++ b/frontend/src/app/features/workout/PostWorkout.tsx
@@ -75,7 +75,7 @@ export function PostWorkout() {
 
         <div className="flex gap-3 mt-auto pt-4 shrink-0">
           <button 
-            onClick={() => navigate('/camera')}
+            onClick={() => navigate("/workout/camera")}
             className="flex-1 bg-[#3FFDD4] text-[#111111] text-[16px] font-bold py-4 rounded-2xl shadow-[0_4px_20px_rgba(63,253,212,0.2)] hover:brightness-110 transition-all active:scale-[0.98]"
           >
             운동 재개

--- a/frontend/src/app/features/workout/RangeCalibrationPage.tsx
+++ b/frontend/src/app/features/workout/RangeCalibrationPage.tsx
@@ -1,0 +1,190 @@
+import { ArrowLeft, CheckCircle2 } from "lucide-react";
+import { useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router";
+
+import { useGoal } from "../../context/GoalContext";
+import squatImg from "../../../assets/exercises/squat.png";
+import { CameraStage } from "./components/CameraStage";
+import { useCameraPreview } from "./hooks/useCameraPreview";
+import { usePoseLandmarker } from "./hooks/usePoseLandmarker";
+
+const TEXT = {
+  title: "스쿼트 범위 설정",
+  minimum: "최초 1회",
+  noticeTitle: "관절 가동 범위 설정",
+  noticeGuide: "본인의 관절 최대 가동 범위를 설정하는 단계입니다.",
+  activeGuide: "고통을 느끼지 전까지 무릎을 최대한 굽혀주세요.",
+  modelError: "AI 자세 분석을 시작할 수 없습니다.",
+  completeTitle: "가동 범위 설정 완료!",
+  start: "자세 설정 시작",
+  detect: "자세 인식 중...",
+  finish: "가동 범위 설정 완료",
+  next: "다음",
+} as const;
+
+function CalibrationCompleteStage() {
+  return (
+    <section className="rounded-[20px] border border-[#242933] bg-[#15181E] p-[10px]">
+      <div className="relative min-h-[700px] overflow-hidden rounded-[16px] bg-[#171A20]">
+        <div className="pointer-events-none absolute inset-0">
+          <div className="absolute left-5 top-5 h-7 w-7 border-l-[4px] border-t-[4px] border-[#3FFDD4]" />
+          <div className="absolute right-5 top-5 h-7 w-7 border-r-[4px] border-t-[4px] border-[#3FFDD4]" />
+          <div className="absolute bottom-5 left-5 h-7 w-7 border-b-[4px] border-l-[4px] border-[#3FFDD4]" />
+          <div className="absolute bottom-5 right-5 h-7 w-7 border-b-[4px] border-r-[4px] border-[#3FFDD4]" />
+        </div>
+
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-5">
+          <div className="flex h-[110px] w-[110px] items-center justify-center rounded-full bg-[#173A34]">
+            <CheckCircle2 className="text-[#3FFDD4]" size={62} strokeWidth={2.2} />
+          </div>
+          <p className="text-[28px] font-extrabold tracking-[-0.2px] text-[#3FFDD4]">
+            {TEXT.completeTitle}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function resolveActionLabel(params: {
+  isCalibrationComplete: boolean;
+  isStreaming: boolean;
+  canCompleteCalibration: boolean;
+}): string {
+  const { isCalibrationComplete, isStreaming, canCompleteCalibration } = params;
+  if (isCalibrationComplete) {
+    return TEXT.next;
+  }
+  if (!isStreaming) {
+    return TEXT.start;
+  }
+  if (canCompleteCalibration) {
+    return TEXT.finish;
+  }
+  return TEXT.detect;
+}
+
+export function RangeCalibrationPage() {
+  const navigate = useNavigate();
+  const { exerciseId } = useParams<{ exerciseId: string }>();
+  const { markCalibrated } = useGoal();
+  const [isCalibrationComplete, setIsCalibrationComplete] = useState(false);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  const {
+    cameraStatus,
+    cameraErrorMessage,
+    isStreaming,
+    requestCamera,
+    stopCamera,
+  } = useCameraPreview(videoRef);
+
+  const {
+    poseStatus,
+    poseErrorMessage,
+    hasPoseLandmarks,
+  } = usePoseLandmarker({
+    enabled: isStreaming && !isCalibrationComplete,
+    videoRef,
+    canvasRef,
+  });
+
+  const resolvedExerciseId = exerciseId ?? "squat";
+
+  let noticeMessage = TEXT.noticeGuide;
+  if (isStreaming) {
+    noticeMessage = TEXT.activeGuide;
+  }
+  if (poseStatus === "error") {
+    noticeMessage = poseErrorMessage ?? TEXT.modelError;
+  }
+
+  const handlePrimaryAction = () => {
+    if (isCalibrationComplete) {
+      markCalibrated(resolvedExerciseId);
+      navigate("/workout/camera");
+      return;
+    }
+
+    if (!isStreaming) {
+      void requestCamera();
+      return;
+    }
+
+    setIsCalibrationComplete(true);
+    stopCamera();
+  };
+
+  const canCompleteCalibration = isStreaming && hasPoseLandmarks;
+  const actionLabel = resolveActionLabel({
+    isCalibrationComplete,
+    isStreaming,
+    canCompleteCalibration,
+  });
+  const actionDisabled = !isCalibrationComplete && isStreaming && !canCompleteCalibration;
+
+  return (
+    <div className="flex min-h-[100dvh] items-start justify-center bg-[#080A0D]">
+      <div
+        className="flex w-full max-w-[430px] flex-col px-4 pb-7 pt-3"
+        style={{ minHeight: "100dvh", backgroundColor: "#090B0E" }}
+      >
+        <header className="flex items-center justify-between pt-3">
+          <div className="flex items-center gap-3">
+            <button
+              aria-label="뒤로 가기"
+              className="flex h-9 w-9 items-center justify-center rounded-full bg-transparent text-white/90"
+              onClick={() => navigate(-1)}
+              type="button"
+            >
+              <ArrowLeft size={23} />
+            </button>
+            <img
+              alt={TEXT.title}
+              className="h-8 w-8 object-contain"
+              decoding="async"
+              height={32}
+              src={squatImg}
+              width={32}
+            />
+            <h1 className="text-[18px] font-extrabold leading-none text-white">{TEXT.title}</h1>
+          </div>
+
+          <div className="rounded-full border-2 border-[#39F4D3] bg-[#102C28] px-4 py-[4px]">
+            <span className="text-[13px] font-bold text-[#3FFDD4]">{TEXT.minimum}</span>
+          </div>
+        </header>
+
+        <main className="mt-4 flex flex-1 flex-col gap-4">
+          {isCalibrationComplete ? (
+            <CalibrationCompleteStage />
+          ) : (
+            <CameraStage
+              canvasRef={canvasRef}
+              cameraErrorMessage={cameraErrorMessage}
+              cameraStatus={cameraStatus}
+              isStreaming={isStreaming}
+              noticeMessage={noticeMessage}
+              noticeTitle={TEXT.noticeTitle}
+              onRequestCamera={requestCamera}
+              hideStageButton
+              idleIntroLine1="카메라 권한을 허용하면"
+              idleIntroLine2="스쿼트 가동 범위 분석이 시작됩니다."
+              videoRef={videoRef}
+            />
+          )}
+        </main>
+
+        <button
+          className="mt-5 rounded-[16px] bg-[#3FEED0] py-4 text-[19px] font-extrabold text-[#081B16] disabled:cursor-not-allowed disabled:bg-[#2A4A43] disabled:text-[#9CC7BE]"
+          disabled={actionDisabled}
+          onClick={handlePrimaryAction}
+          type="button"
+        >
+          {actionLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/features/workout/RangeCalibrationPage.tsx
+++ b/frontend/src/app/features/workout/RangeCalibrationPage.tsx
@@ -15,6 +15,7 @@ const TEXT = {
   noticeGuide: "본인의 관절 최대 가동 범위를 설정하는 단계입니다.",
   activeGuide: "고통을 느끼지 전까지 무릎을 최대한 굽혀주세요.",
   modelError: "AI 자세 분석을 시작할 수 없습니다.",
+  retry: "다시 시도",
   completeTitle: "가동 범위 설정 완료!",
   start: "자세 설정 시작",
   detect: "자세 인식 중...",
@@ -50,10 +51,14 @@ function resolveActionLabel(params: {
   isCalibrationComplete: boolean;
   isStreaming: boolean;
   canCompleteCalibration: boolean;
+  isPoseError: boolean;
 }): string {
-  const { isCalibrationComplete, isStreaming, canCompleteCalibration } = params;
+  const { isCalibrationComplete, isStreaming, canCompleteCalibration, isPoseError } = params;
   if (isCalibrationComplete) {
     return TEXT.next;
+  }
+  if (isPoseError) {
+    return TEXT.retry;
   }
   if (!isStreaming) {
     return TEXT.start;
@@ -91,12 +96,13 @@ export function RangeCalibrationPage() {
   });
 
   const resolvedExerciseId = exerciseId ?? "squat";
+  const isPoseError = poseStatus === "error";
 
   let noticeMessage: string = TEXT.noticeGuide;
   if (isStreaming) {
     noticeMessage = TEXT.activeGuide;
   }
-  if (poseStatus === "error") {
+  if (isPoseError) {
     noticeMessage = poseErrorMessage ?? TEXT.modelError;
   }
 
@@ -104,6 +110,12 @@ export function RangeCalibrationPage() {
     if (isCalibrationComplete) {
       markCalibrated(resolvedExerciseId);
       navigate("/workout/camera");
+      return;
+    }
+
+    if (isPoseError) {
+      stopCamera();
+      void requestCamera();
       return;
     }
 
@@ -121,8 +133,9 @@ export function RangeCalibrationPage() {
     isCalibrationComplete,
     isStreaming,
     canCompleteCalibration,
+    isPoseError,
   });
-  const actionDisabled = !isCalibrationComplete && isStreaming && !canCompleteCalibration;
+  const actionDisabled = !isCalibrationComplete && !isPoseError && isStreaming && !canCompleteCalibration;
 
   return (
     <div className="flex min-h-[100dvh] items-start justify-center bg-[#080A0D]">

--- a/frontend/src/app/features/workout/RangeCalibrationPage.tsx
+++ b/frontend/src/app/features/workout/RangeCalibrationPage.tsx
@@ -92,7 +92,7 @@ export function RangeCalibrationPage() {
 
   const resolvedExerciseId = exerciseId ?? "squat";
 
-  let noticeMessage = TEXT.noticeGuide;
+  let noticeMessage: string = TEXT.noticeGuide;
   if (isStreaming) {
     noticeMessage = TEXT.activeGuide;
   }

--- a/frontend/src/app/features/workout/components/CameraStage.tsx
+++ b/frontend/src/app/features/workout/components/CameraStage.tsx
@@ -1,0 +1,176 @@
+import { Camera, LoaderCircle, RefreshCw, TriangleAlert, VideoOff } from "lucide-react";
+import type { RefObject } from "react";
+
+import type { CameraStatus } from "../types/workoutSession";
+
+interface CameraStageProps {
+  canvasRef: RefObject<HTMLCanvasElement | null>;
+  videoRef: RefObject<HTMLVideoElement | null>;
+  cameraStatus: CameraStatus;
+  cameraErrorMessage: string | null;
+  isStreaming: boolean;
+  noticeTitle: string;
+  noticeMessage: string;
+  onRequestCamera: () => Promise<void>;
+  hideStageButton?: boolean;
+  idleIntroLine1?: string;
+  idleIntroLine2?: string;
+}
+
+const TEXT = {
+  loading: "\uce74\uba54\ub77c\ub97c \uc5f0\uacb0\ud558\uace0 \uc788\uc2b5\ub2c8\ub2e4...",
+  denied: "\uce74\uba54\ub77c \uad8c\ud55c\uc774 \uac70\ubd80\ub418\uc5c8\uc2b5\ub2c8\ub2e4.",
+  noDevice: "\uce74\uba54\ub77c \uc7a5\uce58\ub97c \ucc3e\uc744 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4.",
+  generalError: "\uce74\uba54\ub77c \uc5f0\uacb0 \uc911 \uc624\ub958\uac00 \ubc1c\uc0dd\ud588\uc2b5\ub2c8\ub2e4.",
+  intro1: "\uce74\uba54\ub77c \uad8c\ud55c\uc744 \ud5c8\uc6a9\ud558\uba74",
+  intro2: "\uc2e4\uc2dc\uac04 \uc790\uc138 \ubd84\uc11d\uc774 \uc2dc\uc791\ub429\ub2c8\ub2e4",
+  buttonLoading: "\uce74\uba54\ub77c \uc5f0\uacb0 \uc911...",
+  buttonStart: "\uce74\uba54\ub77c \uc2dc\uc791",
+  buttonRetry: "\ub2e4\uc2dc \uc2dc\ub3c4",
+} as const;
+
+function StageMessage({
+  cameraStatus,
+  cameraErrorMessage,
+  idleIntroLine1,
+  idleIntroLine2,
+}: Pick<CameraStageProps, "cameraStatus" | "cameraErrorMessage" | "idleIntroLine1" | "idleIntroLine2">) {
+  if (cameraStatus === "loading") {
+    return (
+      <div className="flex flex-col items-center gap-3 text-center">
+        <LoaderCircle className="animate-spin text-[#3FFDD4]" size={34} />
+        <p className="text-[15px] font-medium text-[#D4D8DB]">{TEXT.loading}</p>
+      </div>
+    );
+  }
+
+  if (cameraStatus === "permission_denied") {
+    return (
+      <div className="flex flex-col items-center gap-3 text-center">
+        <TriangleAlert className="text-[#FF8A80]" size={32} />
+        <p className="text-[15px] font-medium text-[#D4D8DB]">{TEXT.denied}</p>
+        {cameraErrorMessage && <p className="text-[13px] text-[#8F959B]">{cameraErrorMessage}</p>}
+      </div>
+    );
+  }
+
+  if (cameraStatus === "no_camera_device") {
+    return (
+      <div className="flex flex-col items-center gap-3 text-center">
+        <VideoOff className="text-[#FFB74D]" size={32} />
+        <p className="text-[15px] font-medium text-[#D4D8DB]">{TEXT.noDevice}</p>
+        {cameraErrorMessage && <p className="text-[13px] text-[#8F959B]">{cameraErrorMessage}</p>}
+      </div>
+    );
+  }
+
+  if (cameraStatus === "general_error") {
+    return (
+      <div className="flex flex-col items-center gap-3 text-center">
+        <TriangleAlert className="text-[#FF8A80]" size={32} />
+        <p className="text-[15px] font-medium text-[#D4D8DB]">{TEXT.generalError}</p>
+        {cameraErrorMessage && <p className="text-[13px] text-[#8F959B]">{cameraErrorMessage}</p>}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-3 text-center">
+      <div className="flex h-[96px] w-[96px] items-center justify-center rounded-full border-[3px] border-dashed border-[#3FFDD4]">
+        <Camera className="text-[#3FFDD4]" size={34} />
+      </div>
+      <p className="text-[15px] font-semibold text-[#656A73]">{idleIntroLine1 ?? TEXT.intro1}</p>
+      <p className="text-[15px] font-semibold text-[#656A73]">{idleIntroLine2 ?? TEXT.intro2}</p>
+    </div>
+  );
+}
+
+export function CameraStage({
+  canvasRef,
+  videoRef,
+  cameraStatus,
+  cameraErrorMessage,
+  isStreaming,
+  noticeTitle,
+  noticeMessage,
+  onRequestCamera,
+  hideStageButton = false,
+  idleIntroLine1,
+  idleIntroLine2,
+}: CameraStageProps) {
+  const requestButtonLabel =
+    cameraStatus === "loading"
+      ? TEXT.buttonLoading
+      : cameraStatus === "ready"
+        ? TEXT.buttonStart
+        : TEXT.buttonRetry;
+
+  return (
+    <section className="rounded-[20px] border border-[#242933] bg-[#15181E] p-[10px]">
+      <div className="relative min-h-[700px] overflow-hidden rounded-[16px] bg-[#171A20]">
+        <video
+          autoPlay
+          className={`absolute inset-0 h-full w-full object-cover transition-opacity duration-300 ${
+            isStreaming ? "opacity-100" : "opacity-20"
+          }`}
+          muted
+          playsInline
+          ref={videoRef}
+        />
+        <canvas
+          className={`pointer-events-none absolute inset-0 z-[5] h-full w-full transition-opacity duration-300 ${
+            isStreaming ? "opacity-100" : "opacity-0"
+          }`}
+          ref={canvasRef}
+        />
+
+        <div className="pointer-events-none absolute inset-0">
+          <div className="absolute left-5 top-5 h-7 w-7 border-l-[4px] border-t-[4px] border-[#3FFDD4]" />
+          <div className="absolute right-5 top-5 h-7 w-7 border-r-[4px] border-t-[4px] border-[#3FFDD4]" />
+          <div className="absolute bottom-5 left-5 h-7 w-7 border-b-[4px] border-l-[4px] border-[#3FFDD4]" />
+          <div className="absolute bottom-5 right-5 h-7 w-7 border-b-[4px] border-r-[4px] border-[#3FFDD4]" />
+        </div>
+
+        {isStreaming && (
+          <div className="pointer-events-none absolute inset-5 rounded-[16px] border border-dashed border-[#3FFDD455]">
+            {/* Integration boundary: future MediaPipe landmarks/canvas overlay goes here. */}
+          </div>
+        )}
+
+        {!isStreaming && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-8 px-6">
+            <StageMessage
+              cameraErrorMessage={cameraErrorMessage}
+              cameraStatus={cameraStatus}
+              idleIntroLine1={idleIntroLine1}
+              idleIntroLine2={idleIntroLine2}
+            />
+            {!hideStageButton && (
+              <button
+                className="flex min-w-[138px] items-center justify-center gap-2 rounded-[14px] bg-[#3FEED0] px-7 py-[13px] text-[18px] font-extrabold text-[#071A16] disabled:cursor-not-allowed disabled:bg-[#2A4A43] disabled:text-[#9CC7BE]"
+                disabled={cameraStatus === "loading"}
+                onClick={() => {
+                  void onRequestCamera();
+                }}
+                type="button"
+              >
+                {cameraStatus !== "ready" && cameraStatus !== "loading" && <RefreshCw size={16} />}
+                {requestButtonLabel}
+              </button>
+            )}
+          </div>
+        )}
+
+        <div className="absolute bottom-4 left-4 right-4 rounded-[14px] border border-[#2A3038] bg-[#171C23EE] px-4 py-3 backdrop-blur-sm">
+          <div className="mb-1 flex items-center gap-2">
+            <span className="h-2 w-2 rounded-full bg-[#3FEED0]" />
+            <p className="text-[12px] font-bold text-[#3FEED0]">{noticeTitle}</p>
+          </div>
+          <p className="text-[14px] font-semibold leading-6 text-[#D0D5DD]">
+            {noticeMessage}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/app/features/workout/components/WorkoutHeader.tsx
+++ b/frontend/src/app/features/workout/components/WorkoutHeader.tsx
@@ -1,0 +1,62 @@
+import { ArrowLeft } from "lucide-react";
+import { useNavigate } from "react-router";
+
+import type { ExerciseInfo } from "../types/workoutSession";
+
+interface WorkoutHeaderProps {
+  exercise: ExerciseInfo;
+  currentCount?: number;
+}
+
+const TEXT = {
+  back: "\ub4a4\ub85c \uac00\uae30",
+  goalPrefix: "\ubaa9\ud45c ",
+} as const;
+
+export function WorkoutHeader({ exercise, currentCount = 0 }: WorkoutHeaderProps) {
+  const navigate = useNavigate();
+  const hasGoalTarget = exercise.targetCount > 0;
+  const goalProgressCount = hasGoalTarget
+    ? Math.max(0, Math.min(currentCount, exercise.targetCount))
+    : 0;
+
+  return (
+    <header className="flex items-center justify-between pt-3">
+      <div className="flex items-center gap-3">
+        <button
+          aria-label={TEXT.back}
+          className="flex h-9 w-9 items-center justify-center rounded-full bg-transparent text-white/90"
+          onClick={() => navigate(-1)}
+          type="button"
+        >
+          <ArrowLeft size={23} />
+        </button>
+        <div className="flex items-center gap-2">
+          {exercise.iconSrc ? (
+            <img
+              alt={exercise.name}
+              className="h-8 w-8 object-contain"
+              decoding="async"
+              height={32}
+              src={exercise.iconSrc}
+              width={32}
+            />
+          ) : null}
+          <h1 className="text-[18px] font-extrabold leading-none text-white">
+            {exercise.emoji ? `${exercise.emoji} ` : ""}
+            {exercise.name}
+          </h1>
+        </div>
+      </div>
+
+      {hasGoalTarget ? (
+        <div className="rounded-full border-2 border-[#39F4D3] bg-[#102C28] px-4 py-[4px]">
+          <span className="text-[13px] font-bold text-[#3FFDD4]">
+            {TEXT.goalPrefix}
+            {goalProgressCount}/{exercise.targetCount}
+          </span>
+        </div>
+      ) : null}
+    </header>
+  );
+}

--- a/frontend/src/app/features/workout/hooks/useCameraPreview.ts
+++ b/frontend/src/app/features/workout/hooks/useCameraPreview.ts
@@ -100,10 +100,12 @@ export function useCameraPreview(
       const nextStream = await navigator.mediaDevices.getUserMedia(CAMERA_CONSTRAINTS);
       streamRef.current = nextStream;
 
-      if (videoRef.current) {
-        videoRef.current.srcObject = nextStream;
-        await videoRef.current.play().catch(() => undefined);
+      const video = videoRef.current;
+      if (!video) {
+        throw new Error("Camera video element is not ready.");
       }
+      video.srcObject = nextStream;
+      await video.play();
 
       setIsStreaming(true);
       setCameraStatus("ready");

--- a/frontend/src/app/features/workout/hooks/useCameraPreview.ts
+++ b/frontend/src/app/features/workout/hooks/useCameraPreview.ts
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+
+import type { CameraStatus } from "../types/workoutSession";
+
+interface CameraError {
+  status: CameraStatus;
+  message: string;
+}
+
+interface UseCameraPreviewResult {
+  cameraStatus: CameraStatus;
+  cameraErrorMessage: string | null;
+  isStreaming: boolean;
+  requestCamera: () => Promise<void>;
+  stopCamera: () => void;
+}
+
+const CAMERA_CONSTRAINTS: MediaStreamConstraints = {
+  video: {
+    facingMode: "user",
+  },
+  audio: false,
+};
+
+function normalizeCameraError(error: unknown): CameraError {
+  if (error instanceof DOMException) {
+    if (error.name === "NotAllowedError" || error.name === "SecurityError") {
+      return {
+        status: "permission_denied",
+        message:
+          "\uce74\uba54\ub77c \uad8c\ud55c\uc774 \ud544\uc694\ud569\ub2c8\ub2e4. \ube0c\ub77c\uc6b0\uc800 \uc124\uc815\uc5d0\uc11c \uad8c\ud55c\uc744 \ud5c8\uc6a9\ud574 \uc8fc\uc138\uc694.",
+      };
+    }
+
+    if (error.name === "NotFoundError" || error.name === "OverconstrainedError") {
+      return {
+        status: "no_camera_device",
+        message: "\uc0ac\uc6a9 \uac00\ub2a5\ud55c \uce74\uba54\ub77c \uc7a5\uce58\ub97c \ucc3e\uc744 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4.",
+      };
+    }
+  }
+
+  return {
+    status: "general_error",
+    message:
+      "\uce74\uba54\ub77c \uc5f0\uacb0 \uc911 \ubb38\uc81c\uac00 \ubc1c\uc0dd\ud588\uc2b5\ub2c8\ub2e4. \uc7a0\uc2dc \ud6c4 \ub2e4\uc2dc \uc2dc\ub3c4\ud574 \uc8fc\uc138\uc694.",
+  };
+}
+
+export function useCameraPreview(
+  videoRef: RefObject<HTMLVideoElement | null>,
+): UseCameraPreviewResult {
+  const streamRef = useRef<MediaStream | null>(null);
+  const [cameraStatus, setCameraStatus] = useState<CameraStatus>("ready");
+  const [cameraErrorMessage, setCameraErrorMessage] = useState<string | null>(null);
+  const [isStreaming, setIsStreaming] = useState(false);
+
+  const releaseStream = useCallback(() => {
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+    }
+
+    if (videoRef.current) {
+      videoRef.current.srcObject = null;
+    }
+  }, [videoRef]);
+
+  const stopCamera = useCallback(() => {
+    releaseStream();
+    setIsStreaming(false);
+    setCameraStatus("ready");
+    setCameraErrorMessage(null);
+  }, [releaseStream]);
+
+  const requestCamera = useCallback(async () => {
+    if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+      setCameraStatus("general_error");
+      setCameraErrorMessage(
+        "\ube0c\ub77c\uc6b0\uc800\uc5d0\uc11c \uce74\uba54\ub77c API\ub97c \uc9c0\uc6d0\ud558\uc9c0 \uc54a\uc2b5\ub2c8\ub2e4.",
+      );
+      return;
+    }
+
+    setCameraStatus("loading");
+    setCameraErrorMessage(null);
+
+    try {
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      const hasVideoInput = devices.some((device) => device.kind === "videoinput");
+
+      if (!hasVideoInput) {
+        setCameraStatus("no_camera_device");
+        setCameraErrorMessage("\uce74\uba54\ub77c \uc7a5\uce58\ub97c \ucc3e\uc744 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4.");
+        return;
+      }
+
+      releaseStream();
+
+      const nextStream = await navigator.mediaDevices.getUserMedia(CAMERA_CONSTRAINTS);
+      streamRef.current = nextStream;
+
+      if (videoRef.current) {
+        videoRef.current.srcObject = nextStream;
+        await videoRef.current.play().catch(() => undefined);
+      }
+
+      setIsStreaming(true);
+      setCameraStatus("ready");
+    } catch (error) {
+      releaseStream();
+      setIsStreaming(false);
+      const normalizedError = normalizeCameraError(error);
+      setCameraStatus(normalizedError.status);
+      setCameraErrorMessage(normalizedError.message);
+    }
+  }, [releaseStream, videoRef]);
+
+  useEffect(() => {
+    return () => {
+      releaseStream();
+    };
+  }, [releaseStream]);
+
+  return {
+    cameraStatus,
+    cameraErrorMessage,
+    isStreaming,
+    requestCamera,
+    stopCamera,
+  };
+}

--- a/frontend/src/app/features/workout/hooks/usePoseLandmarker.ts
+++ b/frontend/src/app/features/workout/hooks/usePoseLandmarker.ts
@@ -278,9 +278,6 @@ export function usePoseLandmarker({
 
   useEffect(() => {
     if (!enabled) {
-      setPoseStatus("idle");
-      setPoseErrorMessage(null);
-      setHasPoseLandmarks(false);
       hasPoseLandmarksRef.current = false;
       onPoseLandmarksRef.current?.(null, performance.now());
       if (frameRef.current !== null) {
@@ -374,8 +371,8 @@ export function usePoseLandmarker({
   }, [canvasRef, enabled, videoRef]);
 
   return {
-    poseStatus,
-    poseErrorMessage,
-    hasPoseLandmarks,
+    poseStatus: enabled ? poseStatus : "idle",
+    poseErrorMessage: enabled ? poseErrorMessage : null,
+    hasPoseLandmarks: enabled ? hasPoseLandmarks : false,
   };
 }

--- a/frontend/src/app/features/workout/hooks/usePoseLandmarker.ts
+++ b/frontend/src/app/features/workout/hooks/usePoseLandmarker.ts
@@ -53,11 +53,11 @@ interface UsePoseLandmarkerResult {
   hasPoseLandmarks: boolean;
 }
 
-const MP_ESM_URL =
-  "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.14/+esm";
-const MP_SCRIPT_URL =
-  "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision/vision_bundle.js";
-const MP_WASM_ROOT = "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision/wasm";
+const MP_VERSION = "0.10.14";
+const MP_PACKAGE = `@mediapipe/tasks-vision@${MP_VERSION}`;
+const MP_ESM_URL = `https://cdn.jsdelivr.net/npm/${MP_PACKAGE}/+esm`;
+const MP_SCRIPT_URL = `https://cdn.jsdelivr.net/npm/${MP_PACKAGE}/vision_bundle.js`;
+const MP_WASM_ROOT = `https://cdn.jsdelivr.net/npm/${MP_PACKAGE}/wasm`;
 const MP_MODEL_URL =
   "https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_lite/float16/1/pose_landmarker_lite.task";
 
@@ -103,9 +103,17 @@ async function ensureScriptLoaded(): Promise<void> {
 
   if (!scriptPromise) {
     scriptPromise = new Promise<void>((resolve, reject) => {
-      const existing = document.querySelector(
+      let existing = document.querySelector(
         `script[data-mediapipe-vision="true"]`,
       ) as HTMLScriptElement | null;
+
+      if (existing) {
+        const loadState = existing.dataset.mediapipeLoadState;
+        if (loadState === "error") {
+          existing.remove();
+          existing = null;
+        }
+      }
 
       if (existing) {
         existing.addEventListener("load", () => resolve(), { once: true });
@@ -122,13 +130,31 @@ async function ensureScriptLoaded(): Promise<void> {
       script.async = true;
       script.crossOrigin = "anonymous";
       script.dataset.mediapipeVision = "true";
-      script.onload = () => resolve();
-      script.onerror = () => reject(new Error("Failed to load MediaPipe script."));
+      script.dataset.mediapipeLoadState = "loading";
+      script.onload = () => {
+        script.dataset.mediapipeLoadState = "loaded";
+        resolve();
+      };
+      script.onerror = () => {
+        script.dataset.mediapipeLoadState = "error";
+        reject(new Error("Failed to load MediaPipe script."));
+      };
       document.head.appendChild(script);
     });
   }
 
-  await scriptPromise;
+  try {
+    await scriptPromise;
+  } catch (error) {
+    scriptPromise = null;
+    document.querySelectorAll(`script[data-mediapipe-vision="true"]`).forEach((scriptNode) => {
+      const script = scriptNode as HTMLScriptElement;
+      if (script.dataset.mediapipeLoadState === "error") {
+        script.remove();
+      }
+    });
+    throw error;
+  }
 }
 
 async function loadRuntime(): Promise<VisionRuntime> {

--- a/frontend/src/app/features/workout/hooks/usePoseLandmarker.ts
+++ b/frontend/src/app/features/workout/hooks/usePoseLandmarker.ts
@@ -1,0 +1,381 @@
+import { useEffect, useRef, useState, type RefObject } from "react";
+
+import type { NormalizedLandmark, PoseOverlayStatus } from "../types/pose";
+
+interface MediapipePoseResult {
+  landmarks?: NormalizedLandmark[][];
+}
+
+interface MediapipePoseLandmarker {
+  detectForVideo: (video: HTMLVideoElement, timestampMs: number) => MediapipePoseResult;
+  close?: () => void;
+}
+
+interface FilesetResolverLike {
+  forVisionTasks: (wasmPath: string) => Promise<unknown>;
+}
+
+interface PoseLandmarkerFactoryLike {
+  createFromOptions: (
+    vision: unknown,
+    options: Record<string, unknown>,
+  ) => Promise<MediapipePoseLandmarker>;
+}
+
+interface VisionRuntime {
+  FilesetResolver: FilesetResolverLike;
+  PoseLandmarker: PoseLandmarkerFactoryLike;
+}
+
+interface VisionModuleLike {
+  FilesetResolver?: FilesetResolverLike;
+  PoseLandmarker?: PoseLandmarkerFactoryLike;
+}
+
+declare global {
+  interface Window {
+    vision?: VisionModuleLike;
+    FilesetResolver?: FilesetResolverLike;
+    PoseLandmarker?: PoseLandmarkerFactoryLike;
+  }
+}
+
+interface UsePoseLandmarkerParams {
+  enabled: boolean;
+  videoRef: RefObject<HTMLVideoElement | null>;
+  canvasRef: RefObject<HTMLCanvasElement | null>;
+  onPoseLandmarks?: (landmarks: NormalizedLandmark[] | null, timestampMs: number) => void;
+}
+
+interface UsePoseLandmarkerResult {
+  poseStatus: PoseOverlayStatus;
+  poseErrorMessage: string | null;
+  hasPoseLandmarks: boolean;
+}
+
+const MP_ESM_URL =
+  "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.14/+esm";
+const MP_SCRIPT_URL =
+  "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision/vision_bundle.js";
+const MP_WASM_ROOT = "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision/wasm";
+const MP_MODEL_URL =
+  "https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_lite/float16/1/pose_landmarker_lite.task";
+
+const POSE_CONNECTIONS: ReadonlyArray<readonly [number, number]> = [
+  [0, 1], [1, 2], [2, 3], [3, 7],
+  [0, 4], [4, 5], [5, 6], [6, 8],
+  [9, 10],
+  [11, 12],
+  [11, 13], [13, 15], [15, 17], [15, 19], [15, 21], [17, 19],
+  [12, 14], [14, 16], [16, 18], [16, 20], [16, 22], [18, 20],
+  [11, 23], [12, 24], [23, 24],
+  [23, 25], [24, 26],
+  [25, 27], [26, 28],
+  [27, 29], [28, 30], [29, 31], [30, 32],
+  [27, 31], [28, 32],
+];
+
+let runtimePromise: Promise<VisionRuntime> | null = null;
+let scriptPromise: Promise<void> | null = null;
+
+function resolveGlobalRuntime(): VisionRuntime | null {
+  if (window.vision?.FilesetResolver && window.vision.PoseLandmarker) {
+    return {
+      FilesetResolver: window.vision.FilesetResolver,
+      PoseLandmarker: window.vision.PoseLandmarker,
+    };
+  }
+
+  if (window.FilesetResolver && window.PoseLandmarker) {
+    return {
+      FilesetResolver: window.FilesetResolver,
+      PoseLandmarker: window.PoseLandmarker,
+    };
+  }
+
+  return null;
+}
+
+async function ensureScriptLoaded(): Promise<void> {
+  if (resolveGlobalRuntime()) {
+    return;
+  }
+
+  if (!scriptPromise) {
+    scriptPromise = new Promise<void>((resolve, reject) => {
+      const existing = document.querySelector(
+        `script[data-mediapipe-vision="true"]`,
+      ) as HTMLScriptElement | null;
+
+      if (existing) {
+        existing.addEventListener("load", () => resolve(), { once: true });
+        existing.addEventListener(
+          "error",
+          () => reject(new Error("Failed to load MediaPipe script.")),
+          { once: true },
+        );
+        return;
+      }
+
+      const script = document.createElement("script");
+      script.src = MP_SCRIPT_URL;
+      script.async = true;
+      script.crossOrigin = "anonymous";
+      script.dataset.mediapipeVision = "true";
+      script.onload = () => resolve();
+      script.onerror = () => reject(new Error("Failed to load MediaPipe script."));
+      document.head.appendChild(script);
+    });
+  }
+
+  await scriptPromise;
+}
+
+async function loadRuntime(): Promise<VisionRuntime> {
+  if (!runtimePromise) {
+    runtimePromise = (async () => {
+      try {
+        const module = (await import(
+          /* @vite-ignore */ MP_ESM_URL
+        )) as VisionModuleLike;
+
+        if (module.FilesetResolver && module.PoseLandmarker) {
+          return {
+            FilesetResolver: module.FilesetResolver,
+            PoseLandmarker: module.PoseLandmarker,
+          };
+        }
+      } catch {
+        // fallback to global script
+      }
+
+      await ensureScriptLoaded();
+      const globalRuntime = resolveGlobalRuntime();
+      if (globalRuntime) {
+        return globalRuntime;
+      }
+
+      throw new Error("MediaPipe runtime is not available.");
+    })();
+  }
+
+  try {
+    return await runtimePromise;
+  } catch (error) {
+    runtimePromise = null;
+    throw error;
+  }
+}
+
+function mapCoverPoint(
+  landmark: NormalizedLandmark,
+  videoWidth: number,
+  videoHeight: number,
+  canvasWidth: number,
+  canvasHeight: number,
+): { x: number; y: number } {
+  const scale = Math.max(canvasWidth / videoWidth, canvasHeight / videoHeight);
+  const drawWidth = videoWidth * scale;
+  const drawHeight = videoHeight * scale;
+  const offsetX = (canvasWidth - drawWidth) / 2;
+  const offsetY = (canvasHeight - drawHeight) / 2;
+
+  return {
+    x: offsetX + landmark.x * drawWidth,
+    y: offsetY + landmark.y * drawHeight,
+  };
+}
+
+function drawLandmarks(
+  canvas: HTMLCanvasElement,
+  landmarks: NormalizedLandmark[] | undefined,
+  videoWidth: number,
+  videoHeight: number,
+) {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    return;
+  }
+
+  const viewWidth = canvas.clientWidth;
+  const viewHeight = canvas.clientHeight;
+  const dpr = window.devicePixelRatio || 1;
+
+  const targetWidth = Math.max(1, Math.round(viewWidth * dpr));
+  const targetHeight = Math.max(1, Math.round(viewHeight * dpr));
+  if (canvas.width !== targetWidth || canvas.height !== targetHeight) {
+    canvas.width = targetWidth;
+    canvas.height = targetHeight;
+  }
+
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.clearRect(0, 0, viewWidth, viewHeight);
+
+  if (!landmarks || landmarks.length === 0 || videoWidth <= 0 || videoHeight <= 0) {
+    return;
+  }
+
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+  ctx.strokeStyle = "rgba(63, 238, 208, 0.9)";
+  ctx.fillStyle = "#B7FFF2";
+
+  for (const [startIndex, endIndex] of POSE_CONNECTIONS) {
+    const start = landmarks[startIndex];
+    const end = landmarks[endIndex];
+    if (!start || !end) {
+      continue;
+    }
+
+    if ((start.visibility ?? 1) < 0.3 || (end.visibility ?? 1) < 0.3) {
+      continue;
+    }
+
+    const startPoint = mapCoverPoint(
+      start,
+      videoWidth,
+      videoHeight,
+      viewWidth,
+      viewHeight,
+    );
+    const endPoint = mapCoverPoint(end, videoWidth, videoHeight, viewWidth, viewHeight);
+
+    ctx.beginPath();
+    ctx.lineWidth = 2.4;
+    ctx.moveTo(startPoint.x, startPoint.y);
+    ctx.lineTo(endPoint.x, endPoint.y);
+    ctx.stroke();
+  }
+
+  for (const landmark of landmarks) {
+    if ((landmark.visibility ?? 1) < 0.35) {
+      continue;
+    }
+
+    const point = mapCoverPoint(landmark, videoWidth, videoHeight, viewWidth, viewHeight);
+    ctx.beginPath();
+    ctx.arc(point.x, point.y, 3.2, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+export function usePoseLandmarker({
+  enabled,
+  videoRef,
+  canvasRef,
+  onPoseLandmarks,
+}: UsePoseLandmarkerParams): UsePoseLandmarkerResult {
+  const [poseStatus, setPoseStatus] = useState<PoseOverlayStatus>("idle");
+  const [poseErrorMessage, setPoseErrorMessage] = useState<string | null>(null);
+  const [hasPoseLandmarks, setHasPoseLandmarks] = useState(false);
+  const hasPoseLandmarksRef = useRef(false);
+  const frameRef = useRef<number | null>(null);
+  const onPoseLandmarksRef = useRef(onPoseLandmarks);
+
+  useEffect(() => {
+    onPoseLandmarksRef.current = onPoseLandmarks;
+  }, [onPoseLandmarks]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setPoseStatus("idle");
+      setPoseErrorMessage(null);
+      setHasPoseLandmarks(false);
+      hasPoseLandmarksRef.current = false;
+      onPoseLandmarksRef.current?.(null, performance.now());
+      if (frameRef.current !== null) {
+        window.cancelAnimationFrame(frameRef.current);
+        frameRef.current = null;
+      }
+      const canvas = canvasRef.current;
+      if (canvas) {
+        const ctx = canvas.getContext("2d");
+        ctx?.clearRect(0, 0, canvas.width, canvas.height);
+      }
+      return undefined;
+    }
+
+    let cancelled = false;
+    let poseLandmarker: MediapipePoseLandmarker | null = null;
+
+    const start = async () => {
+      setPoseStatus("loading");
+      setPoseErrorMessage(null);
+
+      try {
+        const runtime = await loadRuntime();
+        const vision = await runtime.FilesetResolver.forVisionTasks(MP_WASM_ROOT);
+        poseLandmarker = await runtime.PoseLandmarker.createFromOptions(vision, {
+          baseOptions: { modelAssetPath: MP_MODEL_URL },
+          runningMode: "VIDEO",
+          numPoses: 1,
+          minPoseDetectionConfidence: 0.5,
+          minPosePresenceConfidence: 0.5,
+          minTrackingConfidence: 0.5,
+        });
+
+        if (cancelled) {
+          poseLandmarker.close?.();
+          return;
+        }
+
+        setPoseStatus("ready");
+
+        const loop = () => {
+          if (cancelled || !poseLandmarker) {
+            return;
+          }
+
+          const video = videoRef.current;
+          const canvas = canvasRef.current;
+
+          if (!video || !canvas || video.readyState < 2) {
+            onPoseLandmarksRef.current?.(null, performance.now());
+            frameRef.current = window.requestAnimationFrame(loop);
+            return;
+          }
+
+          const timestampMs = performance.now();
+          const result = poseLandmarker.detectForVideo(video, timestampMs);
+          const firstPose = result.landmarks?.[0];
+
+          drawLandmarks(canvas, firstPose, video.videoWidth, video.videoHeight);
+          const hasLandmarks = Boolean(firstPose && firstPose.length > 0);
+          if (hasLandmarks !== hasPoseLandmarksRef.current) {
+            hasPoseLandmarksRef.current = hasLandmarks;
+            setHasPoseLandmarks(hasLandmarks);
+          }
+          onPoseLandmarksRef.current?.(firstPose ?? null, timestampMs);
+          frameRef.current = window.requestAnimationFrame(loop);
+        };
+
+        frameRef.current = window.requestAnimationFrame(loop);
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+        setPoseStatus("error");
+        setPoseErrorMessage(
+          error instanceof Error ? error.message : "Failed to initialize MediaPipe.",
+        );
+      }
+    };
+
+    void start();
+
+    return () => {
+      cancelled = true;
+      if (frameRef.current !== null) {
+        window.cancelAnimationFrame(frameRef.current);
+        frameRef.current = null;
+      }
+      poseLandmarker?.close?.();
+    };
+  }, [canvasRef, enabled, videoRef]);
+
+  return {
+    poseStatus,
+    poseErrorMessage,
+    hasPoseLandmarks,
+  };
+}

--- a/frontend/src/app/features/workout/hooks/useSquatAnalysis.ts
+++ b/frontend/src/app/features/workout/hooks/useSquatAnalysis.ts
@@ -1,0 +1,254 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { NormalizedLandmark } from "../types/pose";
+import type { SquatAnalysisSnapshot, SquatAnalysisStatus } from "../types/squat";
+
+interface UseSquatAnalysisParams {
+  enabled: boolean;
+}
+
+interface UseSquatAnalysisResult {
+  analysis: SquatAnalysisSnapshot;
+  onPoseLandmarks: (landmarks: NormalizedLandmark[] | null, timestampMs: number) => void;
+}
+
+interface BackendFeedbackPayload {
+  timestampMs?: number;
+  status?: string;
+  feedbackMessage?: string;
+  feedback?: string;
+  message?: string;
+  fullRepCount?: number;
+  count?: number;
+}
+
+const LANDMARK_SEND_INTERVAL_MS = 100;
+const WS_URL_FALLBACK = "ws://localhost:8000/ws/workout-feedback";
+const DISCONNECTED_STATUS: SquatAnalysisStatus = "insufficient_visibility";
+
+const STATUS_MAP: Record<SquatAnalysisStatus, true> = {
+  idle: true,
+  tracking: true,
+  insufficient_visibility: true,
+};
+
+function createInitialAnalysis(): SquatAnalysisSnapshot {
+  return {
+    timestampMs: 0,
+    status: "idle",
+    feedbackMessage: "",
+    fullRepCount: 0,
+  };
+}
+
+function resolveWebSocketUrl(): string {
+  const configured = (import.meta.env as Record<string, string | undefined>).VITE_WORKOUT_WS_URL;
+  if (typeof configured === "string" && configured.trim().length > 0) {
+    return configured.trim();
+  }
+  return WS_URL_FALLBACK;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  return null;
+}
+
+function isSquatAnalysisStatus(value: unknown): value is SquatAnalysisStatus {
+  return typeof value === "string" && Object.prototype.hasOwnProperty.call(STATUS_MAP, value);
+}
+
+function toMessageFromPayload(payload: BackendFeedbackPayload): string | null {
+  const candidates = [payload.feedbackMessage, payload.feedback, payload.message];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string") {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function parseBackendFeedback(raw: unknown): BackendFeedbackPayload | null {
+  if (typeof raw !== "string" || raw.length === 0) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { feedbackMessage: raw };
+  }
+
+  if (!isRecord(parsed)) {
+    return null;
+  }
+
+  const payload = isRecord(parsed.data) ? parsed.data : parsed;
+
+  return {
+    timestampMs: toNumber(payload.timestampMs) ?? undefined,
+    status: typeof payload.status === "string" ? payload.status : undefined,
+    feedbackMessage:
+      typeof payload.feedbackMessage === "string" ? payload.feedbackMessage : undefined,
+    feedback: typeof payload.feedback === "string" ? payload.feedback : undefined,
+    message: typeof payload.message === "string" ? payload.message : undefined,
+    fullRepCount: toNumber(payload.fullRepCount) ?? toNumber(payload.count) ?? undefined,
+  };
+}
+
+function buildPosePayload(
+  landmarks: NormalizedLandmark[] | null,
+  timestampMs: number,
+): string {
+  return JSON.stringify({
+    type: "pose_landmarks",
+    timestampMs,
+    landmarks: landmarks ?? [],
+  });
+}
+
+export function useSquatAnalysis({
+  enabled,
+}: UseSquatAnalysisParams): UseSquatAnalysisResult {
+  const [analysis, setAnalysis] = useState<SquatAnalysisSnapshot>(createInitialAnalysis);
+  const socketRef = useRef<WebSocket | null>(null);
+  const lastSentAtMsRef = useRef(0);
+
+  const onPoseLandmarks = useCallback(
+    (landmarks: NormalizedLandmark[] | null, timestampMs: number) => {
+      if (!enabled) {
+        return;
+      }
+
+      const socket = socketRef.current;
+      if (!socket || socket.readyState !== WebSocket.OPEN) {
+        return;
+      }
+
+      if (timestampMs - lastSentAtMsRef.current < LANDMARK_SEND_INTERVAL_MS) {
+        return;
+      }
+
+      lastSentAtMsRef.current = timestampMs;
+      try {
+        socket.send(buildPosePayload(landmarks, timestampMs));
+      } catch {
+        // Ignore send errors; connection state is handled by onclose/onerror.
+      }
+    },
+    [enabled],
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      lastSentAtMsRef.current = 0;
+      setAnalysis((prev) => {
+        if (
+          prev.status === "idle"
+          && prev.feedbackMessage.length === 0
+          && prev.fullRepCount === 0
+          && prev.timestampMs === 0
+        ) {
+          return prev;
+        }
+        return createInitialAnalysis();
+      });
+      if (socketRef.current) {
+        socketRef.current.close();
+        socketRef.current = null;
+      }
+      return;
+    }
+
+    let isDisposed = false;
+    const socket = new WebSocket(resolveWebSocketUrl());
+    socketRef.current = socket;
+
+    socket.onopen = () => {
+      if (isDisposed) {
+        return;
+      }
+      setAnalysis((prev) => (
+        prev.status === "tracking"
+          ? prev
+          : { ...prev, status: "tracking" }
+      ));
+    };
+
+    socket.onmessage = (event) => {
+      if (isDisposed) {
+        return;
+      }
+      const feedback = parseBackendFeedback(event.data);
+      if (!feedback) {
+        return;
+      }
+
+      setAnalysis((prev) => {
+        const nextMessage = toMessageFromPayload(feedback) ?? prev.feedbackMessage;
+        const nextCount = feedback.fullRepCount ?? prev.fullRepCount;
+        const nextStatus = isSquatAnalysisStatus(feedback.status) ? feedback.status : prev.status;
+        const nextTimestamp = feedback.timestampMs ?? performance.now();
+
+        if (
+          nextMessage === prev.feedbackMessage
+          && nextCount === prev.fullRepCount
+          && nextStatus === prev.status
+        ) {
+          return prev;
+        }
+
+        return {
+          timestampMs: nextTimestamp,
+          status: nextStatus,
+          feedbackMessage: nextMessage,
+          fullRepCount: nextCount,
+        };
+      });
+    };
+
+    const handleDisconnected = () => {
+      if (isDisposed) {
+        return;
+      }
+      setAnalysis((prev) => (
+        prev.status === DISCONNECTED_STATUS
+          ? prev
+          : { ...prev, status: DISCONNECTED_STATUS }
+      ));
+    };
+
+    socket.onerror = handleDisconnected;
+
+    socket.onclose = () => {
+      handleDisconnected();
+      if (socketRef.current === socket) {
+        socketRef.current = null;
+      }
+    };
+
+    return () => {
+      isDisposed = true;
+      socket.onopen = null;
+      socket.onmessage = null;
+      socket.onerror = null;
+      socket.onclose = null;
+      if (socketRef.current === socket) {
+        socketRef.current = null;
+      }
+      socket.close();
+    };
+  }, [enabled]);
+
+  return {
+    analysis,
+    onPoseLandmarks,
+  };
+}

--- a/frontend/src/app/features/workout/hooks/useSquatAnalysis.ts
+++ b/frontend/src/app/features/workout/hooks/useSquatAnalysis.ts
@@ -32,13 +32,15 @@ const STATUS_MAP: Record<SquatAnalysisStatus, true> = {
   insufficient_visibility: true,
 };
 
+const INITIAL_ANALYSIS: SquatAnalysisSnapshot = {
+  timestampMs: 0,
+  status: "idle",
+  feedbackMessage: "",
+  fullRepCount: 0,
+};
+
 function createInitialAnalysis(): SquatAnalysisSnapshot {
-  return {
-    timestampMs: 0,
-    status: "idle",
-    feedbackMessage: "",
-    fullRepCount: 0,
-  };
+  return { ...INITIAL_ANALYSIS };
 }
 
 function resolveWebSocketUrl(): string {
@@ -149,17 +151,6 @@ export function useSquatAnalysis({
   useEffect(() => {
     if (!enabled) {
       lastSentAtMsRef.current = 0;
-      setAnalysis((prev) => {
-        if (
-          prev.status === "idle"
-          && prev.feedbackMessage.length === 0
-          && prev.fullRepCount === 0
-          && prev.timestampMs === 0
-        ) {
-          return prev;
-        }
-        return createInitialAnalysis();
-      });
       if (socketRef.current) {
         socketRef.current.close();
         socketRef.current = null;
@@ -248,7 +239,7 @@ export function useSquatAnalysis({
   }, [enabled]);
 
   return {
-    analysis,
+    analysis: enabled ? analysis : INITIAL_ANALYSIS,
     onPoseLandmarks,
   };
 }

--- a/frontend/src/app/features/workout/types/pose.ts
+++ b/frontend/src/app/features/workout/types/pose.ts
@@ -1,0 +1,8 @@
+export interface NormalizedLandmark {
+  x: number;
+  y: number;
+  z?: number;
+  visibility?: number;
+}
+
+export type PoseOverlayStatus = "idle" | "loading" | "ready" | "error";

--- a/frontend/src/app/features/workout/types/squat.ts
+++ b/frontend/src/app/features/workout/types/squat.ts
@@ -1,0 +1,8 @@
+export type SquatAnalysisStatus = "idle" | "tracking" | "insufficient_visibility";
+
+export interface SquatAnalysisSnapshot {
+  timestampMs: number;
+  status: SquatAnalysisStatus;
+  feedbackMessage: string;
+  fullRepCount: number;
+}

--- a/frontend/src/app/features/workout/types/workoutSession.ts
+++ b/frontend/src/app/features/workout/types/workoutSession.ts
@@ -1,0 +1,14 @@
+export type CameraStatus =
+  | "ready"
+  | "loading"
+  | "permission_denied"
+  | "no_camera_device"
+  | "general_error";
+
+export interface ExerciseInfo {
+  id: string;
+  name: string;
+  emoji?: string;
+  iconSrc?: string;
+  targetCount: number;
+}

--- a/frontend/src/app/routes.ts
+++ b/frontend/src/app/routes.ts
@@ -3,6 +3,8 @@ import { createBrowserRouter } from "react-router";
 import { LoginPage } from "./features/auth/LoginPage";
 import { SignUpPage } from "./features/auth/SignUpPage";
 import { FindPasswordPage } from "./features/auth/FindPasswordPage";
+import { CameraAnalysisPage } from "./features/workout/CameraAnalysisPage";
+import { RangeCalibrationPage } from "./features/workout/RangeCalibrationPage";
 
 import { GoalBirthdayPage } from "./features/onboarding/GoalBirthdayPage";
 import { GoalWeeklyPage } from "./features/onboarding/GoalWeeklyPage";
@@ -18,7 +20,7 @@ import { PostWorkout } from "./features/workout/PostWorkout";
 import { Community } from "./features/community/Community";
 import { CreatePost } from "./features/community/CreatePost";
 
-import { AnalysisPage } from './features/analysis/AnalysisPage';
+import { AnalysisPage } from "./features/analysis/AnalysisPage";
 
 
 export const router = createBrowserRouter([
@@ -33,7 +35,8 @@ export const router = createBrowserRouter([
   { path: "/goal/ready", Component: GoalReadyPage },
 
   { path: "/main", Component: MainPage },
-
+  { path: "/workout/calibration/:exerciseId", Component: RangeCalibrationPage },
+  { path: "/workout/camera", Component: CameraAnalysisPage },
   { path: "/post-workout", Component: PostWorkout },
   { path: "/community", Component: Community },
   { path: "/create-post", Component: CreatePost },


### PR DESCRIPTION
## Summary

관련 있는 Issue를 태그해주세요.
Closes #46

스쿼트 진입 시 최초 1회 사용자에게 가동범위 설정 단계를 먼저 제공하고,
설정 완료 후 분석 화면으로 자연스럽게 이동하는 플로우가 필요해 작업했습니다.

## Tasks

- 스쿼트 최초 1회 가동범위 설정 페이지 추가
  - 경로: `/workout/calibration/:exerciseId`
- 메인 페이지에서 스쿼트 클릭 시 최초 1회는 가동범위 설정 페이지로 이동
- 가동범위 설정 완료 후 분석 페이지(`/workout/camera`)로 이동
- 가동범위 설정 페이지 UI/문구 피그마 기준 반영
- MediaPipe Pose Landmarker 연동
- 카메라 프레임에서 랜드마크(좌표) 추출 및 캔버스 오버레이 렌더링
- 운동 종료 버튼 클릭 시 결과 페이지(`/post-workout`) 이동

## To Reviewer

- 웹소켓 방식의 서버 연동/프로토콜 고정은 후속 PR에서 별도로 진행 예정입니다.
- 이번 PR은 화면/플로우/MediaPipe 좌표 추출 기반 구조 정리에 초점을 맞췄습니다.
- 피드백 제공해주시면 감사하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * AI 기반 운동 자세 분석 기능 추가 - 카메라로 운동 자세를 실시간 분석하고 즉각적인 피드백 제공
  * 운동 범위 교정 기능 추가 - 초기 설정 시 개인 맞춤형 운동 범위 설정 가능
  * 실시간 반복 횟수 카운팅 및 자세 피드백 제공

* **개선사항**
  * 운동 화면 네비게이션 경로 일관성 개선
  * 운동 헤더에 목표 진행 상황 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->