### PR TITLE
Feature/BE-68: 운동 분석 페이지 WebSocket 기반 피드백 송/수신 구조 설정

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,17 +1,17 @@
 from contextlib import asynccontextmanager
 from importlib import import_module
+from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
-from pathlib import Path
 
-from app.core.database import get_engine, Base
 from app.auth.router import router as auth_router
-from app.users.router import router as users_router
 from app.board.router import router as board_router
+from app.core.database import Base, get_engine
 from app.exercise.exercise_router import router as exercise_router
 from app.exercise_record.exercise_record_router import router as exercise_record_router
 from app.pose.pose_controller import router as pose_router
+from app.users.router import router as users_router
 
 
 BASE_DIR = Path(__file__).resolve().parents[1]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,6 +11,7 @@ from app.users.router import router as users_router
 from app.board.router import router as board_router
 from app.exercise.exercise_router import router as exercise_router
 from app.exercise_record.exercise_record_router import router as exercise_record_router
+from app.pose.pose_controller import router as pose_router
 
 
 BASE_DIR = Path(__file__).resolve().parents[1]
@@ -50,3 +51,4 @@ app.include_router(exercise_record_router)
 app.include_router(auth_router)
 app.include_router(users_router)
 app.include_router(board_router)
+app.include_router(pose_router)

--- a/backend/app/pose/pose_controller.py
+++ b/backend/app/pose/pose_controller.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from starlette.websockets import WebSocketState
+
+from app.pose.pose_service import DEFAULT_GOAL_COUNT, PoseFeedbackService
+
+
+router = APIRouter(tags=["pose"])
+pose_feedback_service = PoseFeedbackService()
+
+
+@router.websocket("/ws/workout-feedback")
+async def workout_feedback_websocket(websocket: WebSocket) -> None:
+    await websocket.accept()
+    session_state = pose_feedback_service.create_session(goal_count=DEFAULT_GOAL_COUNT)
+
+    async def send_error(message: str) -> None:
+        if websocket.client_state != WebSocketState.CONNECTED:
+            return
+        await websocket.send_json(
+            pose_feedback_service.build_error_message(message, state=session_state),
+        )
+
+    await websocket.send_json(
+        pose_feedback_service.build_session_started_message(session_state),
+    )
+
+    try:
+        while True:
+            raw_text = await websocket.receive_text()
+            try:
+                payload = json.loads(raw_text)
+            except json.JSONDecodeError:
+                await send_error("잘못된 JSON 형식입니다.")
+                continue
+
+            if not isinstance(payload, dict):
+                await send_error("JSON payload는 객체여야 합니다.")
+                continue
+
+            response = pose_feedback_service.handle_message(
+                session_state,
+                payload=payload,
+            )
+            await websocket.send_json(response)
+    except WebSocketDisconnect:
+        return

--- a/backend/app/pose/pose_service.py
+++ b/backend/app/pose/pose_service.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+DEFAULT_GOAL_COUNT = 10
+DEFAULT_POSE_ISSUE = "무릎이 발끝과 같은 방향을 유지하도록 해주세요."
+SESSION_STARTED_MESSAGE = "자세 세션이 시작되었습니다. pose_landmarks 프레임을 전송해주세요."
+UNSUPPORTED_MESSAGE_TYPE = "지원하지 않는 메시지 타입입니다."
+NO_LANDMARKS_MESSAGE = "주요 관절이 보이도록 화면 안으로 들어와 주세요."
+INSUFFICIENT_LANDMARKS_MESSAGE = "안정적인 피드백을 위해 더 많은 관절 좌표가 필요합니다."
+DEFAULT_FEEDBACK_MESSAGE = "가슴을 세우고 스쿼트 깊이를 일정하게 유지해 주세요."
+
+
+@dataclass
+class PoseSessionState:
+    goal_count: int = DEFAULT_GOAL_COUNT
+    full_rep_count: int = 0
+    last_timestamp_ms: float = 0.0
+    last_pose_issue: str = DEFAULT_POSE_ISSUE
+
+
+class PoseFeedbackService:
+    def create_session(self, goal_count: int = DEFAULT_GOAL_COUNT) -> PoseSessionState:
+        normalized_goal = goal_count if goal_count > 0 else DEFAULT_GOAL_COUNT
+        return PoseSessionState(goal_count=normalized_goal)
+
+    def build_session_started_message(self, state: PoseSessionState) -> dict[str, Any]:
+        return {
+            "type": "session_started",
+            "status": "idle",
+            "feedbackMessage": SESSION_STARTED_MESSAGE,
+            "fullRepCount": state.full_rep_count,
+            "goalCount": state.goal_count,
+            "timestampMs": state.last_timestamp_ms,
+        }
+
+    def build_error_message(
+        self,
+        message: str,
+        state: PoseSessionState | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "type": "error",
+            "status": "insufficient_visibility",
+            "feedbackMessage": message,
+            "fullRepCount": state.full_rep_count if state else 0,
+            "goalCount": state.goal_count if state else DEFAULT_GOAL_COUNT,
+            "timestampMs": state.last_timestamp_ms if state else 0.0,
+        }
+
+    def handle_message(
+        self,
+        state: PoseSessionState,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        message_type = payload.get("type")
+
+        if message_type == "ping":
+            return {"type": "pong"}
+
+        if message_type != "pose_landmarks":
+            return self.build_error_message(UNSUPPORTED_MESSAGE_TYPE, state=state)
+
+        return self._handle_pose_landmarks(state, payload)
+
+    def _handle_pose_landmarks(
+        self,
+        state: PoseSessionState,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        timestamp_ms = self._to_timestamp_ms(payload.get("timestampMs"))
+        goal_count = self._to_positive_int(payload.get("goalCount"))
+        if goal_count is not None:
+            state.goal_count = goal_count
+
+        landmarks = payload.get("landmarks")
+        current_issue = self._resolve_pose_issue(landmarks)
+
+        rep_completed = self._to_bool(payload.get("repCompleted"))
+        feedback_message = current_issue
+
+        if rep_completed and state.full_rep_count < state.goal_count:
+            previous_issue = state.last_pose_issue
+            state.full_rep_count += 1
+            feedback_message = (
+                f"{state.full_rep_count}회 완료. "
+                f"이전 자세 피드백: {previous_issue}"
+            )
+
+        state.last_pose_issue = current_issue
+        state.last_timestamp_ms = timestamp_ms
+
+        status = "tracking"
+        if state.full_rep_count >= state.goal_count:
+            status = "idle"
+
+        return {
+            "type": "feedback",
+            "status": status,
+            "feedbackMessage": feedback_message,
+            "fullRepCount": state.full_rep_count,
+            "goalCount": state.goal_count,
+            "timestampMs": state.last_timestamp_ms,
+        }
+
+    @staticmethod
+    def _to_timestamp_ms(value: Any) -> float:
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, str):
+            try:
+                parsed = float(value)
+            except ValueError:
+                return 0.0
+            if parsed >= 0:
+                return parsed
+        return 0.0
+
+    @staticmethod
+    def _to_positive_int(value: Any) -> int | None:
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, (int, float)) and int(value) > 0:
+            return int(value)
+        return None
+
+    @staticmethod
+    def _to_bool(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            return value != 0
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"true", "1", "yes", "y"}:
+                return True
+            if normalized in {"false", "0", "no", "n", ""}:
+                return False
+        return False
+
+    @staticmethod
+    def _resolve_pose_issue(landmarks: Any) -> str:
+        if not isinstance(landmarks, list) or len(landmarks) == 0:
+            return NO_LANDMARKS_MESSAGE
+
+        if len(landmarks) < 10:
+            return INSUFFICIENT_LANDMARKS_MESSAGE
+
+        return DEFAULT_FEEDBACK_MESSAGE

--- a/backend/app/pose/pose_service.py
+++ b/backend/app/pose/pose_service.py
@@ -6,10 +6,14 @@ from typing import Any
 
 DEFAULT_GOAL_COUNT = 10
 DEFAULT_POSE_ISSUE = "무릎이 발끝과 같은 방향을 유지하도록 해주세요."
-SESSION_STARTED_MESSAGE = "자세 세션이 시작되었습니다. pose_landmarks 프레임을 전송해주세요."
+SESSION_STARTED_MESSAGE = (
+    "자세 세션이 시작되었습니다. pose_landmarks 프레임을 전송해주세요."
+)
 UNSUPPORTED_MESSAGE_TYPE = "지원하지 않는 메시지 타입입니다."
 NO_LANDMARKS_MESSAGE = "주요 관절이 보이도록 화면 안으로 들어와 주세요."
-INSUFFICIENT_LANDMARKS_MESSAGE = "안정적인 피드백을 위해 더 많은 관절 좌표가 필요합니다."
+INSUFFICIENT_LANDMARKS_MESSAGE = (
+    "안정적인 피드백을 위해 더 많은 관절 좌표가 필요합니다."
+)
 DEFAULT_FEEDBACK_MESSAGE = "가슴을 세우고 스쿼트 깊이를 일정하게 유지해 주세요."
 
 
@@ -85,8 +89,7 @@ class PoseFeedbackService:
             previous_issue = state.last_pose_issue
             state.full_rep_count += 1
             feedback_message = (
-                f"{state.full_rep_count}회 완료. "
-                f"이전 자세 피드백: {previous_issue}"
+                f"{state.full_rep_count}회 완료. 이전 자세 피드백: {previous_issue}"
             )
 
         state.last_pose_issue = current_issue

--- a/backend/tests/test_pose_websocket.py
+++ b/backend/tests/test_pose_websocket.py
@@ -1,0 +1,75 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def test_pose_websocket_session_start_message():
+    with client.websocket_connect("/ws/workout-feedback") as websocket:
+        message = websocket.receive_json()
+        assert message["type"] == "session_started"
+        assert message["status"] == "idle"
+        assert message["fullRepCount"] == 0
+        assert message["goalCount"] == 10
+
+
+def test_pose_websocket_invalid_json_error():
+    with client.websocket_connect("/ws/workout-feedback") as websocket:
+        websocket.receive_json()  # session_started
+        websocket.send_text("not-json")
+        message = websocket.receive_json()
+        assert message["type"] == "error"
+        assert message["feedbackMessage"] == "잘못된 JSON 형식입니다."
+
+
+def test_pose_websocket_feedback_flow_with_rep_completion():
+    with client.websocket_connect("/ws/workout-feedback") as websocket:
+        websocket.receive_json()  # session_started
+
+        websocket.send_json(
+            {
+                "type": "pose_landmarks",
+                "timestampMs": 1000,
+                "goalCount": 10,
+                "landmarks": [{"x": 0.1, "y": 0.2}] * 33,
+            },
+        )
+        first_feedback = websocket.receive_json()
+        assert first_feedback["type"] == "feedback"
+        assert first_feedback["status"] == "tracking"
+        assert first_feedback["fullRepCount"] == 0
+
+        websocket.send_json(
+            {
+                "type": "pose_landmarks",
+                "timestampMs": 1120,
+                "repCompleted": True,
+                "landmarks": [{"x": 0.1, "y": 0.2}] * 33,
+            },
+        )
+        second_feedback = websocket.receive_json()
+        assert second_feedback["type"] == "feedback"
+        assert second_feedback["status"] == "tracking"
+        assert second_feedback["fullRepCount"] == 1
+        assert "이전 자세 피드백" in second_feedback["feedbackMessage"]
+
+
+def test_pose_websocket_string_false_rep_completed_does_not_increment():
+    with client.websocket_connect("/ws/workout-feedback") as websocket:
+        websocket.receive_json()  # session_started
+
+        websocket.send_json(
+            {
+                "type": "pose_landmarks",
+                "timestampMs": 1000,
+                "goalCount": 10,
+                "repCompleted": "false",
+                "landmarks": [{"x": 0.1, "y": 0.2}] * 33,
+            },
+        )
+        feedback = websocket.receive_json()
+        assert feedback["type"] == "feedback"
+        assert feedback["status"] == "tracking"
+        assert feedback["fullRepCount"] == 0

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -40,6 +40,17 @@ services:
         condition: service_healthy
       redis-test:
         condition: service_started
-
+  frontend:
+    image: gympt-frontend
+    build:
+      context: ../frontend
+      dockerfile: Dockerfile
+    ports:
+      - "${FRONTEND_PORT:-5173}:5173"
+    environment:
+      - VITE_API_URL=http://localhost:8001
+      - VITE_WORKOUT_WS_URL=ws://localhost:8001/ws/workout-feedback
+    depends_on:
+      - backend-test
 volumes:
   mysql_test_data:

--- a/frontend/src/app/features/workout/hooks/useSquatAnalysis.ts
+++ b/frontend/src/app/features/workout/hooks/useSquatAnalysis.ts
@@ -23,8 +23,11 @@ interface BackendFeedbackPayload {
 }
 
 const LANDMARK_SEND_INTERVAL_MS = 100;
-const WS_URL_FALLBACK = "ws://localhost:8000/ws/workout-feedback";
+const WORKOUT_FEEDBACK_PATH = "/ws/workout-feedback";
+const LEGACY_POSE_PATH = "/ws/pose";
+const WS_URL_FALLBACK = `ws://localhost:8000${WORKOUT_FEEDBACK_PATH}`;
 const DISCONNECTED_STATUS: SquatAnalysisStatus = "insufficient_visibility";
+const DISCONNECTED_MESSAGE = "백엔드 연결이 끊겼습니다. 다시 연결을 시도해주세요.";
 
 const STATUS_MAP: Record<SquatAnalysisStatus, true> = {
   idle: true,
@@ -43,11 +46,50 @@ function createInitialAnalysis(): SquatAnalysisSnapshot {
   return { ...INITIAL_ANALYSIS };
 }
 
-function resolveWebSocketUrl(): string {
-  const configured = (import.meta.env as Record<string, string | undefined>).VITE_WORKOUT_WS_URL;
-  if (typeof configured === "string" && configured.trim().length > 0) {
-    return configured.trim();
+function toWebSocketUrl(rawUrl: string): string | null {
+  try {
+    const parsed = new URL(rawUrl);
+    const protocol =
+      parsed.protocol === "https:"
+        ? "wss:"
+        : parsed.protocol === "http:"
+          ? "ws:"
+          : parsed.protocol;
+
+    if (protocol !== "ws:" && protocol !== "wss:") {
+      return null;
+    }
+
+    const pathname = parsed.pathname === "/" ? WORKOUT_FEEDBACK_PATH : parsed.pathname;
+    const normalizedPath = pathname.endsWith(LEGACY_POSE_PATH)
+      ? `${pathname.slice(0, -LEGACY_POSE_PATH.length)}${WORKOUT_FEEDBACK_PATH}`
+      : pathname;
+
+    return `${protocol}//${parsed.host}${normalizedPath}${parsed.search}${parsed.hash}`;
+  } catch {
+    return null;
   }
+}
+
+function resolveWebSocketUrl(): string {
+  const env = import.meta.env as Record<string, string | undefined>;
+  const configured = env.VITE_WORKOUT_WS_URL ?? env.VITE_WS_URL;
+
+  if (typeof configured === "string" && configured.trim().length > 0) {
+    const wsUrl = toWebSocketUrl(configured.trim());
+    if (wsUrl) {
+      return wsUrl;
+    }
+  }
+
+  const apiUrl = env.VITE_API_URL;
+  if (typeof apiUrl === "string" && apiUrl.trim().length > 0) {
+    const wsUrl = toWebSocketUrl(apiUrl.trim());
+    if (wsUrl) {
+      return wsUrl;
+    }
+  }
+
   return WS_URL_FALLBACK;
 }
 
@@ -58,6 +100,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function toNumber(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) {
     return value;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
   }
   return null;
 }
@@ -77,15 +125,16 @@ function toMessageFromPayload(payload: BackendFeedbackPayload): string | null {
 }
 
 function parseBackendFeedback(raw: unknown): BackendFeedbackPayload | null {
-  if (typeof raw !== "string" || raw.length === 0) {
-    return null;
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return { feedbackMessage: raw };
+  let parsed: unknown = raw;
+  if (typeof raw === "string") {
+    if (raw.length === 0) {
+      return null;
+    }
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { feedbackMessage: raw };
+    }
   }
 
   if (!isRecord(parsed)) {
@@ -122,6 +171,7 @@ export function useSquatAnalysis({
   const [analysis, setAnalysis] = useState<SquatAnalysisSnapshot>(createInitialAnalysis);
   const socketRef = useRef<WebSocket | null>(null);
   const lastSentAtMsRef = useRef(0);
+  const disconnectNotifiedRef = useRef(false);
 
   const onPoseLandmarks = useCallback(
     (landmarks: NormalizedLandmark[] | null, timestampMs: number) => {
@@ -151,6 +201,7 @@ export function useSquatAnalysis({
   useEffect(() => {
     if (!enabled) {
       lastSentAtMsRef.current = 0;
+      disconnectNotifiedRef.current = false;
       if (socketRef.current) {
         socketRef.current.close();
         socketRef.current = null;
@@ -166,6 +217,7 @@ export function useSquatAnalysis({
       if (isDisposed) {
         return;
       }
+      disconnectNotifiedRef.current = false;
       setAnalysis((prev) => (
         prev.status === "tracking"
           ? prev
@@ -206,13 +258,19 @@ export function useSquatAnalysis({
     };
 
     const handleDisconnected = () => {
-      if (isDisposed) {
+      if (isDisposed || disconnectNotifiedRef.current) {
         return;
       }
+      disconnectNotifiedRef.current = true;
       setAnalysis((prev) => (
         prev.status === DISCONNECTED_STATUS
+          && prev.feedbackMessage === DISCONNECTED_MESSAGE
           ? prev
-          : { ...prev, status: DISCONNECTED_STATUS }
+          : {
+            ...prev,
+            status: DISCONNECTED_STATUS,
+            feedbackMessage: DISCONNECTED_MESSAGE,
+          }
       ));
     };
 


### PR DESCRIPTION
## Summary

>- 관련 있는 Issue를 태그해주세요. #53 

**운동 분석 페이지에서 WebSocket 기반으로 피드백을 송/수신하는 구조로 설정했습니다. Mediapipe를 활용해 추출한 좌표들을
백엔드로 WebSocket기반으로 송신하면 백엔드에서는 해당 좌표값들을 기반으로 피드백을 제공합니다.**

## Tasks

- MediaPipe 랜드마크 좌표를 WebSocket으로 전송하는 프론트 훅 정리
- 백엔드 pose_controller / pose_service 파일 구조 확립
- docker-compose-test.yml 프론트엔드 추가

## To Reviewer

_피드백 제공해주시면 빠른 시일 내에 수정하겠습니다!_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경사항

* **새로운 기능**
  * WebSocket을 통한 실시간 자세 피드백 기능 추가
  * 운동 세션 시작/진행 상태 및 반복 횟수 자동 추적

* **개선 사항**
  * WebSocket URL 검증·정규화 및 메시지 파싱 강화 (숫자 문자열 변환 포함)
  * 연결 끊김 상태 알림 중복 방지 및 상태 관리 개선
  * 테스트용 환경에 프론트엔드 서비스 추가 (테스트 구성 보강)

* **테스트**
  * WebSocket 피드백 엔드포인트 및 메시지 흐름 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->