### PR TITLE
fix/BE-79: 게시글 목록, 상세보기 응답 데이터 수정

### DIFF
--- a/backend/app/board/repository.py
+++ b/backend/app/board/repository.py
@@ -1,4 +1,4 @@
-from sqlalchemy import case, select, update
+from sqlalchemy import case, select, update, func
 from sqlalchemy.orm import Session
 
 from app.board.models import Board, Comment, Like
@@ -74,17 +74,51 @@ def update_board(
     return board
 
 
-def get_board_list(db: Session) -> list[tuple[Board, str]]:
+def get_board_list(
+    db: Session,
+    current_user_id: int,
+) -> list[tuple[Board, str, bool, int]]:
+    liked_subquery = (
+        select(Like.board_no.label("board_no"))
+        .where(Like.writer_id == current_user_id)
+        .subquery()
+    )
+
+    comments_count_subquery = (
+        select(
+            Comment.board_no.label("board_no"),
+            func.count(Comment.comment_no).label("comments_count"),
+        )
+        .group_by(Comment.board_no)
+        .subquery()
+    )
+
     stmt = (
-        select(Board, User.nickname)
+        select(
+            Board,
+            User.nickname,
+            case(
+                (liked_subquery.c.board_no.is_not(None), True),
+                else_=False,
+            ).label("is_liked"),
+            func.coalesce(comments_count_subquery.c.comments_count, 0).label(
+                "comments_count"
+            ),
+        )
         .join(User, Board.writer_id == User.id)
+        .outerjoin(liked_subquery, liked_subquery.c.board_no == Board.board_no)
+        .outerjoin(
+            comments_count_subquery,
+            comments_count_subquery.c.board_no == Board.board_no,
+        )
         .order_by(Board.upload_date.desc(), Board.board_no.desc())
     )
 
     result = db.execute(stmt).all()
-    rows = [(board, nickname) for board, nickname in result]
-
-    return rows
+    return [
+        (board, nickname, is_liked, comments_count)
+        for board, nickname, is_liked, comments_count in result
+    ]
 
 
 def get_board_detail(db: Session, board_no: int) -> tuple[Board, str] | None:
@@ -113,6 +147,24 @@ def get_comments_by_board_no(db: Session, board_no: int) -> list[tuple[Comment, 
 
     result = db.execute(stmt).all()
     return [(comment, nickname) for comment, nickname in result]
+
+
+def get_comment_count_by_board_no(db: Session, board_no: int) -> int:
+    stmt = select(func.count(Comment.comment_no)).where(Comment.board_no == board_no)
+    result = db.execute(stmt).scalar_one()
+    return int(result)
+
+
+def is_board_liked_by_user(
+    db: Session,
+    board_no: int,
+    user_id: int,
+) -> bool:
+    stmt = select(Like.likes_no).where(
+        Like.board_no == board_no,
+        Like.writer_id == user_id,
+    )
+    return db.execute(stmt).scalar_one_or_none() is not None
 
 
 def delete_board(db: Session, board: Board) -> None:

--- a/backend/app/board/router.py
+++ b/backend/app/board/router.py
@@ -33,6 +33,7 @@ from app.board.service import (
     update_comment_service,
     delete_comment_service,
 )
+from app.board import repository
 
 
 router = APIRouter(prefix="/api/v1/board", tags=["Board"])
@@ -78,6 +79,8 @@ def create_board(
         "imgpath": board.imgpath,
         "writer": current_user.nickname,
         "likes": board.likes,
+        "is_liked": False,
+        "comments_count": 0,
         "upload_date": board.upload_date,
     }
 
@@ -130,6 +133,16 @@ def update_board(
         delete_image=delete_image,
     )
 
+    is_liked = repository.is_board_liked_by_user(
+        db=db,
+        board_no=board.board_no,
+        user_id=int(current_user.id),
+    )
+    comments_count = repository.get_comment_count_by_board_no(
+        db=db,
+        board_no=board.board_no,
+    )
+
     return {
         "board_no": board.board_no,
         "title": board.title,
@@ -137,6 +150,8 @@ def update_board(
         "imgpath": board.imgpath,
         "writer": current_user.nickname,
         "likes": board.likes,
+        "is_liked": is_liked,
+        "comments_count": comments_count,
         "upload_date": board.upload_date,
     }
 
@@ -151,7 +166,10 @@ def list_boards(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    return list_boards_service(db)
+    return list_boards_service(
+        db=db,
+        current_user=current_user,
+    )
 
 
 @router.get(
@@ -169,7 +187,11 @@ def get_board_detail(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    return get_board_detail_service(db=db, board_no=board_no)
+    return get_board_detail_service(
+        db=db,
+        board_no=board_no,
+        current_user=current_user,
+    )
 
 
 @router.post(

--- a/backend/app/board/schemas.py
+++ b/backend/app/board/schemas.py
@@ -40,6 +40,16 @@ class BoardResponse(BaseModel):
         description="게시글 작성 시각",
         json_schema_extra={"example": "2026-03-27T10:30:00"},
     )
+    is_liked: bool = Field(
+        ...,
+        description="현재 로그인한 사용자의 좋아요 여부",
+        json_schema_extra={"example": True},
+    )
+    comments_count: int = Field(
+        ...,
+        description="해당 게시글에 달린 댓글 수",
+        json_schema_extra={"example": 3},
+    )
 
 
 class LikeToggleResponse(BaseModel):

--- a/backend/app/board/service.py
+++ b/backend/app/board/service.py
@@ -179,8 +179,14 @@ def update_board_service(
     return updated_board
 
 
-def list_boards_service(db: Session) -> list[BoardResponse]:
-    rows = repository.get_board_list(db)
+def list_boards_service(
+    db: Session,
+    current_user: User,
+) -> list[BoardResponse]:
+    rows = repository.get_board_list(
+        db=db,
+        current_user_id=int(current_user.id),
+    )
 
     return [
         BoardResponse(
@@ -191,12 +197,18 @@ def list_boards_service(db: Session) -> list[BoardResponse]:
             writer=nickname,
             likes=board.likes,
             upload_date=board.upload_date,
+            is_liked=is_liked,
+            comments_count=comments_count,
         )
-        for board, nickname in rows
+        for board, nickname, is_liked, comments_count in rows
     ]
 
 
-def get_board_detail_service(db: Session, board_no: int) -> BoardDetailResponse:
+def get_board_detail_service(
+    db: Session,
+    board_no: int,
+    current_user: User,
+) -> BoardDetailResponse:
     result = repository.get_board_detail(db=db, board_no=board_no)
 
     if result is None:
@@ -207,6 +219,16 @@ def get_board_detail_service(db: Session, board_no: int) -> BoardDetailResponse:
 
     board, nickname = result
     comment_rows = repository.get_comments_by_board_no(db=db, board_no=board_no)
+
+    is_liked = repository.is_board_liked_by_user(
+        db=db,
+        board_no=board_no,
+        user_id=int(current_user.id),
+    )
+    comments_count = repository.get_comment_count_by_board_no(
+        db=db,
+        board_no=board_no,
+    )
 
     comments = [
         CommentResponse(
@@ -228,6 +250,8 @@ def get_board_detail_service(db: Session, board_no: int) -> BoardDetailResponse:
         likes=board.likes,
         upload_date=board.upload_date,
         comments=comments,
+        is_liked=is_liked,
+        comments_count=comments_count,
     )
 
 


### PR DESCRIPTION
## Summary

>- #65 
**게시글 api 연동 관련 수정 사항 반영**

## Tasks

- 게시글 목록 조회 응답 데이터에 좋아요 여부를 체크하는 is_liked 추가
- 게시글 목록 조회 응답 데이터에 각 게시글의 댓글 개수 comment_count 추가



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

- 게시판 목록 및 상세 조회에서 현재 로그인한 사용자의 각 게시글 좋아요 상태 표시
- 각 게시글의 댓글 수를 사용자에게 명확하게 표시
- 사용자별 개인화된 게시판 조회 기능 추가로 향상된 상호작용 경험 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->