### PR TITLE
feature/BE-83: 키, 체중 저장 API 구현

### DIFF
--- a/backend/app/users/models.py
+++ b/backend/app/users/models.py
@@ -25,6 +25,8 @@ class User(Base):
     nickname = Column(String(100), unique=True, nullable=False)
     birth_date = Column(Date, nullable=True)
     weekly_target = Column(Integer, nullable=True)
+    height = Column(Integer, nullable=True)
+    weight = Column(Integer, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     exercise_records = relationship("ExerciseRecord", back_populates="user")

--- a/backend/app/users/router.py
+++ b/backend/app/users/router.py
@@ -9,7 +9,12 @@ from app.core.database import get_db
 from app.exercise.exercise_model import Exercise
 from app.exercise_record.exercise_record_model import ExerciseRecord
 from app.users.models import User, UserExerciseGoal
-from app.users.schemas import BirthDateUpdate, UserResponse, WeeklyTargetUpdate
+from app.users.schemas import (
+    BirthDateUpdate,
+    BodyUpdate,
+    UserResponse,
+    WeeklyTargetUpdate,
+)
 from app.users.dto.user_request import (
     ExerciseGoalCreateRequest,
     ExerciseGoalUpdateRequest,
@@ -187,6 +192,30 @@ def update_weekly_target(
             status_code=status.HTTP_404_NOT_FOUND, detail="유저를 찾을 수 없습니다."
         )
     user.weekly_target = data.weekly_target  # type: ignore[assignment]
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@router.patch(
+    "/me/body",
+    response_model=UserResponse,
+    summary="키, 체중 수정",
+    description="로그인한 사용자의 키와 체중을 수정합니다.",
+)
+def update_body(
+    data: BodyUpdate,
+    token_data: tuple[str, str] = Depends(verify_access_token),
+    db: Session = Depends(get_db),
+):
+    email, _ = token_data
+    user = db.query(User).filter(User.email == email).first()
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="유저를 찾을 수 없습니다."
+        )
+    user.height = data.height  # type: ignore[assignment]
+    user.weight = data.weight  # type: ignore[assignment]
     db.commit()
     db.refresh(user)
     return user

--- a/backend/app/users/schemas.py
+++ b/backend/app/users/schemas.py
@@ -42,6 +42,16 @@ class UserResponse(UserBase):
         description="주간 운동 목표 횟수",
         json_schema_extra={"example": 3},
     )
+    height: int | None = Field(
+        default=None,
+        description="키 (cm)",
+        json_schema_extra={"example": 170},
+    )
+    weight: int | None = Field(
+        default=None,
+        description="몸무게 (kg)",
+        json_schema_extra={"example": 65},
+    )
     created_at: datetime = Field(
         ...,
         description="가입일시",
@@ -64,4 +74,21 @@ class WeeklyTargetUpdate(BaseModel):
         le=7,
         description="주간 운동 목표 횟수 (1~7)",
         json_schema_extra={"example": 3},
+    )
+
+
+class BodyUpdate(BaseModel):
+    height: int = Field(
+        ...,
+        ge=100,
+        le=220,
+        description="키 (cm)",
+        json_schema_extra={"example": 170},
+    )
+    weight: int = Field(
+        ...,
+        ge=30,
+        le=200,
+        description="몸무게 (kg)",
+        json_schema_extra={"example": 65},
     )

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -411,3 +411,48 @@ def test_update_exercise_goal_invalid_threshold(
     )
 
     assert response.status_code == 422
+
+
+# PATCH /me/body
+def test_update_body_success(client, mock_redis_client, access_token, fake_user):
+    test_client, mock_db = client
+    mock_redis_client.get.return_value = None
+    mock_db.query.return_value.filter.return_value.first.return_value = fake_user
+
+    response = test_client.patch(
+        "/api/v1/users/me/body",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={"height": 175, "weight": 70},
+    )
+
+    assert response.status_code == 200
+    assert fake_user.height == 175
+    assert fake_user.weight == 70
+
+
+def test_update_body_user_not_found(client, mock_redis_client, access_token):
+    test_client, mock_db = client
+    mock_redis_client.get.return_value = None
+    mock_db.query.return_value.filter.return_value.first.return_value = None
+
+    response = test_client.patch(
+        "/api/v1/users/me/body",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={"height": 175, "weight": 70},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "유저를 찾을 수 없습니다."
+
+
+def test_update_body_invalid_range(client, mock_redis_client, access_token):
+    test_client, _ = client
+    mock_redis_client.get.return_value = None
+
+    response = test_client.patch(
+        "/api/v1/users/me/body",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={"height": 50, "weight": 70},
+    )
+
+    assert response.status_code == 422

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -428,6 +428,8 @@ def test_update_body_success(client, mock_redis_client, access_token, fake_user)
     assert response.status_code == 200
     assert fake_user.height == 175
     assert fake_user.weight == 70
+    assert response.json()["height"] == 175
+    assert response.json()["weight"] == 70
 
 
 def test_update_body_user_not_found(client, mock_redis_client, access_token):

--- a/docker/mysql-test-init.sql
+++ b/docker/mysql-test-init.sql
@@ -8,6 +8,8 @@ CREATE TABLE IF NOT EXISTS `user` (
   `nickname` VARCHAR(100) NOT NULL,
   `birth_date` DATE NULL,
   `weekly_target` INT NULL,
+  `height` INT NULL,
+  `weight` INT NULL,
   `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   UNIQUE KEY `uq_user_email` (`email`),


### PR DESCRIPTION
## Summary

>- Closes #83
사용자의 키와 체중을 저장/수정하는 API 구현

## Tasks

- User 모델에 height, weight 컬럼 추가
- UserResponse 스키마에 height, weight 필드 추가
- BodyUpdate 요청 스키마 추가
- PATCH /api/v1/users/me/body 엔드포인트 추가



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 프로필에 키 및 체중(옵션) 필드 추가로 저장 가능
  * 인증된 사용자가 본인 신체 정보를 갱신하는 PATCH 엔드포인트 제공
  * 키(100–220cm) 및 체중(30–200kg)에 대한 입력 유효성 검사 적용

* **테스트**
  * 성공, 사용자 미존재(404), 유효성 실패(422)를 검증하는 엔드포인트 테스트 추가

* **데이터베이스**
  * 테스트 스키마에 키/체중 컬럼 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->