### PR TITLE
Bug/[FE-97]메인페이지 운동 달성 현황 연동 수정

### DIFF
--- a/backend/app/users/router.py
+++ b/backend/app/users/router.py
@@ -96,7 +96,7 @@ def get_main_summary(
 
     exercise_ids = sorted(
         {int(g.exercise_id) for g in goals}
-        | {int(record.exercise_id) for record in week_records}
+        | {int(record.exercise_id) for record in today_records}
     )
     exercises = (
         db.query(Exercise).filter(Exercise.id.in_(exercise_ids)).all()

--- a/backend/app/users/router.py
+++ b/backend/app/users/router.py
@@ -94,7 +94,10 @@ def get_main_summary(
 
     today_completed_count = len(today_counts)
 
-    exercise_ids = [int(g.exercise_id) for g in goals]
+    exercise_ids = sorted(
+        {int(g.exercise_id) for g in goals}
+        | {int(record.exercise_id) for record in week_records}
+    )
     exercises = (
         db.query(Exercise).filter(Exercise.id.in_(exercise_ids)).all()
         if exercise_ids
@@ -102,21 +105,24 @@ def get_main_summary(
     )
     exercise_map = {int(e.id): e.name for e in exercises}
 
-    exercise_goal_summaries = [
-        ExerciseGoalSummaryItem(
-            exercise_id=int(goal.exercise_id),
-            exercise_name=str(exercise_map.get(int(goal.exercise_id), "")),
-            daily_target_count=int(goal.daily_target_count)
-            if goal.daily_target_count is not None
-            else None,
-            daily_target_duration=int(goal.daily_target_duration)
-            if goal.daily_target_duration is not None
-            else None,
-            today_count=today_counts.get(int(goal.exercise_id), 0),
-            today_duration=today_durations.get(int(goal.exercise_id), 0),
+    goal_by_exercise_id = {int(goal.exercise_id): goal for goal in goals}
+    exercise_goal_summaries: list[ExerciseGoalSummaryItem] = []
+    for exercise_id in exercise_ids:
+        goal = goal_by_exercise_id.get(exercise_id)
+        exercise_goal_summaries.append(
+            ExerciseGoalSummaryItem(
+                exercise_id=exercise_id,
+                exercise_name=str(exercise_map.get(exercise_id, "")),
+                daily_target_count=int(goal.daily_target_count)
+                if goal and goal.daily_target_count is not None
+                else None,
+                daily_target_duration=int(goal.daily_target_duration)
+                if goal and goal.daily_target_duration is not None
+                else None,
+                today_count=today_counts.get(exercise_id, 0),
+                today_duration=today_durations.get(exercise_id, 0),
+            )
         )
-        for goal in goals
-    ]
 
     worked_days = {r.completed_at.date() for r in week_records}
     weekly_workout_days = [

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -157,6 +157,7 @@ def test_get_main_summary_includes_today_records_without_goals(
     mock_redis_client.get.return_value = None
 
     today = date.today()
+    other_day = today - timedelta(days=1) if today.weekday() else today + timedelta(days=1)
     fake_exercise = Exercise(id=2, name="Squat")
     fake_record = ExerciseRecord(
         id=1,
@@ -167,11 +168,20 @@ def test_get_main_summary_includes_today_records_without_goals(
         calories=10,
         completed_at=datetime.combine(today, datetime.min.time()),
     )
+    fake_other_record = ExerciseRecord(
+        id=2,
+        user_id=1,
+        exercise_id=3,
+        count=5,
+        duration=50,
+        calories=15,
+        completed_at=datetime.combine(other_day, datetime.min.time()),
+    )
 
     mock_db.query.return_value.filter.return_value.first.side_effect = [fake_user]
     mock_db.query.return_value.filter.return_value.all.side_effect = [
         [],
-        [fake_record],
+        [fake_record, fake_other_record],
         [fake_exercise],
     ]
 

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -150,6 +150,52 @@ def test_get_main_summary_no_goals(client, mock_redis_client, access_token, fake
     assert data["weekly_workout_days"] == [False] * 7
 
 
+def test_get_main_summary_includes_today_records_without_goals(
+    client, mock_redis_client, access_token, fake_user
+):
+    test_client, mock_db = client
+    mock_redis_client.get.return_value = None
+
+    today = date.today()
+    fake_exercise = Exercise(id=2, name="Squat")
+    fake_record = ExerciseRecord(
+        id=1,
+        user_id=1,
+        exercise_id=2,
+        count=3,
+        duration=30,
+        calories=10,
+        completed_at=datetime.combine(today, datetime.min.time()),
+    )
+
+    mock_db.query.return_value.filter.return_value.first.side_effect = [fake_user]
+    mock_db.query.return_value.filter.return_value.all.side_effect = [
+        [],
+        [fake_record],
+        [fake_exercise],
+    ]
+
+    response = test_client.get(
+        "/api/v1/users/me/summary",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["today_achievement_rate"] == 0.0
+    assert data["today_completed_count"] == 1
+    assert data["exercise_goals"] == [
+        {
+            "exercise_id": 2,
+            "exercise_name": "Squat",
+            "daily_target_count": None,
+            "daily_target_duration": None,
+            "today_count": 3,
+            "today_duration": 30,
+        }
+    ]
+
+
 def test_get_main_summary_user_not_found(client, mock_redis_client, access_token):
     test_client, mock_db = client
     mock_redis_client.get.return_value = None

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -157,7 +157,9 @@ def test_get_main_summary_includes_today_records_without_goals(
     mock_redis_client.get.return_value = None
 
     today = date.today()
-    other_day = today - timedelta(days=1) if today.weekday() else today + timedelta(days=1)
+    other_day = (
+        today - timedelta(days=1) if today.weekday() else today + timedelta(days=1)
+    )
     fake_exercise = Exercise(id=2, name="Squat")
     fake_record = ExerciseRecord(
         id=1,

--- a/frontend/src/app/features/onboarding/GoalReadyPage.tsx
+++ b/frontend/src/app/features/onboarding/GoalReadyPage.tsx
@@ -3,16 +3,15 @@ import { useNavigate } from 'react-router';
 import { useGoal } from '../../context/GoalContext';
 import { userApi, goalIdStorage, formatBirthDateForApi, localExerciseGoalStorage, onboardingStorage } from '../../api/userApi';
 import { tokenStorage } from '../../api/authApi';
-import { exerciseApi } from '../../api/exerciseApi';
-
-const EXERCISE_NAME_MAP: Record<string, string> = {
-  squat: '스쿼트',
-  lunge: '런지',
-  pushup: '푸시업',
-  plank: '플랭크',
-};
 
 const DURATION_EXERCISES = new Set(['plank']);
+
+const EXERCISE_ID_MAP: Record<string, number> = {
+  pushup: 1,
+  squat: 2,
+  lunge: 3,
+  plank: 4,
+};
 
 function TrainerCharacter() {
   return (
@@ -93,13 +92,8 @@ export function GoalReadyPage() {
       ]);
 
       try {
-        const exercises = await exerciseApi.getList();
-        const nameToId = Object.fromEntries(exercises.map((e) => [e.name, e.id]));
-
         for (const [key, count] of Object.entries(goal.exerciseCounts)) {
-          const koreanName = EXERCISE_NAME_MAP[key];
-          if (!koreanName) continue;
-          const exerciseId = nameToId[koreanName];
+          const exerciseId = EXERCISE_ID_MAP[key];
           if (!exerciseId) continue;
 
           const isDuration = DURATION_EXERCISES.has(key);

--- a/frontend/src/app/features/workout/MainPage.tsx
+++ b/frontend/src/app/features/workout/MainPage.tsx
@@ -116,12 +116,12 @@ export function MainPage() {
   const getExerciseTarget = (exerciseId: string): number => {
     const g = getSummaryGoal(exerciseId);
     if (g) {
-      const fallbackTarget = localCounts[exerciseId] ?? exerciseCounts[exerciseId as keyof typeof exerciseCounts];
+      const fallbackTarget = localCounts[exerciseId] ?? exerciseCounts[exerciseId as keyof typeof exerciseCounts] ?? 0;
       return exerciseId === 'plank'
         ? (g.daily_target_duration ?? fallbackTarget)
         : (g.daily_target_count ?? fallbackTarget);
     }
-    return localCounts[exerciseId] ?? exerciseCounts[exerciseId as keyof typeof exerciseCounts];
+    return localCounts[exerciseId] ?? exerciseCounts[exerciseId as keyof typeof exerciseCounts] ?? 0;
   };
 
   const isExerciseDone = (exerciseId: string): boolean => {

--- a/frontend/src/app/features/workout/MainPage.tsx
+++ b/frontend/src/app/features/workout/MainPage.tsx
@@ -40,6 +40,10 @@ const EXERCISE_ID_MAP: Record<string, number> = {
   plank: 4,
 };
 
+const EXERCISE_KEY_BY_ID = Object.fromEntries(
+  Object.entries(EXERCISE_ID_MAP).map(([key, id]) => [id, key]),
+) as Record<number, string>;
+
 const weeklyData = [
   { day: '월', done: true },
   { day: '화', done: true },
@@ -81,7 +85,7 @@ export function MainPage() {
         if (localExerciseGoalStorage.load().length === 0 && summary.exercise_goals.length > 0) {
           const counts: Record<string, number> = {};
           summary.exercise_goals.forEach((g) => {
-            const key = EXERCISE_KEY_MAP[g.exercise_name];
+            const key = EXERCISE_KEY_BY_ID[g.exercise_id] ?? EXERCISE_KEY_MAP[g.exercise_name];
             if (key) counts[key] = g.daily_target_count ?? g.daily_target_duration ?? 0;
           });
           if (Object.keys(counts).length > 0) {
@@ -96,8 +100,12 @@ export function MainPage() {
   const displayName = profile?.name ?? '';
   const weeklyTarget = profile?.weekly_target ?? goal.weeklyFrequency;
 
-  const getSummaryGoal = (exerciseId: string): ExerciseGoalSummaryItem | undefined =>
-    summaryGoals.find((g) => g.exercise_name === EXERCISE_NAME_MAP[exerciseId]);
+  const getSummaryGoal = (exerciseId: string): ExerciseGoalSummaryItem | undefined => {
+    const backendExerciseId = EXERCISE_ID_MAP[exerciseId];
+    return summaryGoals.find(
+      (g) => g.exercise_id === backendExerciseId || g.exercise_name === EXERCISE_NAME_MAP[exerciseId],
+    );
+  };
 
   const getTodayProgress = (exerciseId: string): number => {
     const g = getSummaryGoal(exerciseId);
@@ -108,9 +116,10 @@ export function MainPage() {
   const getExerciseTarget = (exerciseId: string): number => {
     const g = getSummaryGoal(exerciseId);
     if (g) {
+      const fallbackTarget = localCounts[exerciseId] ?? exerciseCounts[exerciseId as keyof typeof exerciseCounts];
       return exerciseId === 'plank'
-        ? (g.daily_target_duration ?? 0)
-        : (g.daily_target_count ?? 0);
+        ? (g.daily_target_duration ?? fallbackTarget)
+        : (g.daily_target_count ?? fallbackTarget);
     }
     return localCounts[exerciseId] ?? exerciseCounts[exerciseId as keyof typeof exerciseCounts];
   };
@@ -121,8 +130,15 @@ export function MainPage() {
     return target > 0 && progress >= target;
   };
 
-  const completedCount = exercises.filter((ex) => isExerciseDone(ex.id)).length;
-  const achievementRate = completedCount * 25;
+  const progressRates = exercises.map((ex) => {
+    const target = getExerciseTarget(ex.id);
+    if (target <= 0) return 0;
+    return Math.min(getTodayProgress(ex.id) / target, 1);
+  });
+  const completedCount = progressRates.filter((rate) => rate >= 1).length;
+  const achievementRate = Math.round(
+    (progressRates.reduce((sum, rate) => sum + rate, 0) / exercises.length) * 100,
+  );
   const circumference = 2 * Math.PI * 26;
 
   const handleExerciseClick = async (exerciseId: string) => {


### PR DESCRIPTION
## Summary

>- #96 

메인 페이지에서 운동을 완료해도 오늘 운동 진행 현황과 달성률이 반영되지 않는 문제가 있어 수정했습니다.

## Tasks

- [x] 메인 페이지 운동 진행 현황이 exercise_id 기준으로 매칭되도록 수정
- [x] 운동 완료 후 메인 페이지에 현재 수행 횟수 / 목표 횟수가 반영되는지 확인
- [x] 운동 달성률 퍼센티지가 실제 진행량 기준으로 갱신되는지 확인
- [x] 관련 백엔드 테스트 추가 및 기존 테스트 통과 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 목표가 설정되지 않은 운동도 현재 주의 기록에서 추적됩니다.

* **개선 사항**
  * 달성률 계산이 운동별 진행률 기반으로 개선되어 더 정확한 진행 상황을 표시합니다.
  * 명시적 목표 없이도 완료된 운동이 올바르게 기록됩니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GYMPT-Advanced-Capstone/GYMPT/pull/97)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->