### PR TITLE
Feature/[BE-94] 임계값 초기화 API 구현 및 연동

### DIFF
--- a/backend/app/exercise_calibration/service.py
+++ b/backend/app/exercise_calibration/service.py
@@ -37,7 +37,7 @@ class ExerciseCalibrationService:
         exercise_id: int,
     ) -> ExerciseCalibrationResponse:
         calibration = self.repo.get_latest(user_id, exercise_id)
-        if calibration is None:
+        if calibration is None or self._has_no_metrics(calibration):
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="초기 가동범위 설정을 찾을 수 없습니다.",
@@ -90,3 +90,6 @@ class ExerciseCalibrationService:
 
         metrics.update(phase_metrics)
         return metrics
+
+    def _has_no_metrics(self, calibration: UserExerciseCalibration) -> bool:
+        return calibration.metrics_json is None

--- a/backend/app/users/dto/user_response.py
+++ b/backend/app/users/dto/user_response.py
@@ -2,6 +2,11 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class ExerciseGoalSummaryItem(BaseModel):
+    goal_id: int | None = Field(
+        default=None,
+        description="운동 목표 ID",
+        json_schema_extra={"example": 1},
+    )
     exercise_id: int = Field(
         ...,
         description="운동 종목 ID",

--- a/backend/app/users/router.py
+++ b/backend/app/users/router.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.core.database import get_db
 from app.exercise.exercise_model import Exercise
+from app.exercise_record.exercise_record_model import UserExerciseCalibration
 from app.exercise_record.exercise_record_model import ExerciseRecord
 from app.users.models import User, UserExerciseGoal
 from app.users.schemas import (
@@ -111,6 +112,7 @@ def get_main_summary(
         goal = goal_by_exercise_id.get(exercise_id)
         exercise_goal_summaries.append(
             ExerciseGoalSummaryItem(
+                goal_id=int(goal.id) if goal else None,
                 exercise_id=exercise_id,
                 exercise_name=str(exercise_map.get(exercise_id, "")),
                 daily_target_count=int(goal.daily_target_count)
@@ -333,3 +335,56 @@ def update_exercise_goal(
     db.commit()
     db.refresh(goal)
     return goal
+
+
+def reset_goal_threshold_data(
+    user_id: int,
+    goal: UserExerciseGoal,
+    db: Session,
+) -> UserExerciseGoal:
+    goal.threshold = None  # type: ignore[assignment]
+    db.add(
+        UserExerciseCalibration(
+            user_id=user_id,
+            exercise_id=goal.exercise_id,
+            version=1,
+            metrics_json=None,
+        )
+    )
+    db.commit()
+    db.refresh(goal)
+    return goal
+
+
+@router.patch(
+    "/me/exercise-goals/{goal_id}/threshold/reset",
+    response_model=ExerciseGoalResponse,
+    summary="운동 목표 임계값 초기화",
+    description="등록된 운동 목표의 자세 임계값을 초기화합니다. 초기화 후 threshold는 null로 반환됩니다.",
+)
+def reset_exercise_goal_threshold(
+    goal_id: int,
+    token_data: tuple[str, str] = Depends(verify_access_token),
+    db: Session = Depends(get_db),
+):
+    email, _ = token_data
+    user = db.query(User).filter(User.email == email).first()
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="유저를 찾을 수 없습니다."
+        )
+    goal = (
+        db.query(UserExerciseGoal)
+        .filter(
+            UserExerciseGoal.id == goal_id,
+            UserExerciseGoal.user_id == user.id,
+        )
+        .first()
+    )
+    if not goal:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="운동 목표를 찾을 수 없습니다.",
+        )
+
+    return reset_goal_threshold_data(int(user.id), goal, db)

--- a/backend/tests/exercise/test_exercise_calibration.py
+++ b/backend/tests/exercise/test_exercise_calibration.py
@@ -7,6 +7,7 @@ from app.exercise_calibration.dto.exercise_calibration_request import (
     ExerciseCalibrationCreateRequest,
 )
 from app.exercise_calibration.service import ExerciseCalibrationService
+from app.exercise_record.exercise_record_model import UserExerciseCalibration
 
 
 class FakeExerciseCalibrationRepo:
@@ -93,3 +94,20 @@ def test_exercise_calibration_request_rejects_empty_samples():
             hold_duration_ms=3000,
             samples=[],
         )
+
+
+def test_exercise_calibration_service_treats_null_metrics_as_not_found():
+    repo = FakeExerciseCalibrationRepo()
+    repo.created_calibration = UserExerciseCalibration(
+        id=10,
+        user_id=7,
+        exercise_id=1,
+        version=1,
+        metrics_json=None,
+    )
+    service = ExerciseCalibrationService(repo)
+
+    with pytest.raises(Exception) as exc_info:
+        service.get_latest(7, 1)
+
+    assert getattr(exc_info.value, "status_code", None) == 404

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -6,7 +6,10 @@ from sqlalchemy.exc import IntegrityError
 
 from app.users.models import User, UserExerciseGoal
 from app.exercise.exercise_model import Exercise
-from app.exercise_record.exercise_record_model import ExerciseRecord
+from app.exercise_record.exercise_record_model import (
+    ExerciseRecord,
+    UserExerciseCalibration,
+)
 from app.auth.utils import create_token
 from app.core.database import get_db
 
@@ -78,6 +81,7 @@ def test_get_main_summary_success(client, mock_redis_client, access_token, fake_
     assert data["today_achievement_rate"] == 100.0
     assert data["today_completed_count"] == 1
     assert len(data["exercise_goals"]) == 1
+    assert data["exercise_goals"][0]["goal_id"] == 1
     assert data["exercise_goals"][0]["exercise_name"] == "스쿼트"
     assert data["exercise_goals"][0]["today_count"] == 10
     assert data["exercise_goals"][0]["today_duration"] == 60
@@ -123,6 +127,7 @@ def test_get_main_summary_duration_goal(
     assert response.status_code == 200
     data = response.json()
     assert data["today_achievement_rate"] == 100.0
+    assert data["exercise_goals"][0]["goal_id"] == 1
     assert data["exercise_goals"][0]["daily_target_duration"] == 60
     assert data["exercise_goals"][0]["today_duration"] == 60
 
@@ -198,6 +203,7 @@ def test_get_main_summary_includes_today_records_without_goals(
     assert data["today_completed_count"] == 1
     assert data["exercise_goals"] == [
         {
+            "goal_id": None,
             "exercise_id": 2,
             "exercise_name": "Squat",
             "daily_target_count": None,
@@ -465,6 +471,70 @@ def test_update_exercise_goal_invalid_threshold(
     )
 
     assert response.status_code == 422
+
+
+def test_reset_exercise_goal_threshold_success(
+    client, mock_redis_client, access_token, fake_user
+):
+    test_client, mock_db = client
+    mock_redis_client.get.return_value = None
+    fake_goal = UserExerciseGoal(
+        id=1, user_id=1, exercise_id=1, daily_target_count=10, threshold=80.0
+    )
+    mock_db.query.return_value.filter.return_value.first.side_effect = [
+        fake_user,
+        fake_goal,
+    ]
+
+    response = test_client.patch(
+        "/api/v1/users/me/exercise-goals/1/threshold/reset",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert response.status_code == 200
+    assert fake_goal.threshold is None
+    mock_db.add.assert_called_once()
+    added_calibration = mock_db.add.call_args.args[0]
+    assert isinstance(added_calibration, UserExerciseCalibration)
+    assert added_calibration.exercise_id == fake_goal.exercise_id
+    assert added_calibration.metrics_json is None
+    assert response.json()["exercise_id"] == 1
+    assert response.json()["threshold"] is None
+
+
+def test_reset_exercise_goal_threshold_goal_not_found(
+    client, mock_redis_client, access_token, fake_user
+):
+    test_client, mock_db = client
+    mock_redis_client.get.return_value = None
+    mock_db.query.return_value.filter.return_value.first.side_effect = [
+        fake_user,
+        None,
+    ]
+
+    response = test_client.patch(
+        "/api/v1/users/me/exercise-goals/999/threshold/reset",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "운동 목표를 찾을 수 없습니다."
+
+
+def test_reset_exercise_goal_threshold_user_not_found(
+    client, mock_redis_client, access_token
+):
+    test_client, mock_db = client
+    mock_redis_client.get.return_value = None
+    mock_db.query.return_value.filter.return_value.first.return_value = None
+
+    response = test_client.patch(
+        "/api/v1/users/me/exercise-goals/1/threshold/reset",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "유저를 찾을 수 없습니다."
 
 
 # PATCH /me/body

--- a/frontend/src/app/api/userApi.ts
+++ b/frontend/src/app/api/userApi.ts
@@ -160,6 +160,13 @@ export const userApi = {
       { method: 'PATCH', body: JSON.stringify(data) },
       true,
     ),
+
+  resetExerciseGoalThreshold: (goalId: number) =>
+    request<ExerciseGoalResponse>(
+      `/api/v1/users/me/exercise-goals/${goalId}/threshold/reset`,
+      { method: 'PATCH' },
+      true,
+    ),
 };
 
 export function parseBirthDate(dateStr: string | null): { year: number; month: number; day: number } {

--- a/frontend/src/app/context/GoalContext.tsx
+++ b/frontend/src/app/context/GoalContext.tsx
@@ -50,6 +50,7 @@ const GoalContext = createContext<{
   setUserName: (name: string) => void;
   calibratedExercises: Record<string, boolean>;
   markCalibrated: (exerciseId: string) => void;
+  resetCalibrated: (exerciseId: string) => void;
 }>({
   goal: defaultGoal,
   updateGoal: () => {},
@@ -57,6 +58,7 @@ const GoalContext = createContext<{
   setUserName: () => {},
   calibratedExercises: {},
   markCalibrated: () => {},
+  resetCalibrated: () => {},
 });
 
 export function GoalProvider({ children }: { children: ReactNode }) {
@@ -76,8 +78,16 @@ export function GoalProvider({ children }: { children: ReactNode }) {
     setCalibratedExercises((prev) => ({ ...prev, [exerciseId]: true }));
   };
 
+  const resetCalibrated = (exerciseId: string) => {
+    setCalibratedExercises((prev) => {
+      const { [exerciseId]: _removed, ...next } = prev;
+      void _removed;
+      return next;
+    });
+  };
+
   return (
-    <GoalContext.Provider value={{ goal, updateGoal, userName, setUserName, calibratedExercises, markCalibrated }}>
+    <GoalContext.Provider value={{ goal, updateGoal, userName, setUserName, calibratedExercises, markCalibrated, resetCalibrated }}>
       {children}
     </GoalContext.Provider>
   );

--- a/frontend/src/app/features/profile/MyPage.tsx
+++ b/frontend/src/app/features/profile/MyPage.tsx
@@ -58,6 +58,17 @@ const EXERCISE_KEY_MAP: Record<string, string> = {
   런지: 'lunge',
   푸시업: 'pushup',
   플랭크: 'plank',
+  Squat: 'squat',
+  Lunge: 'lunge',
+  'Push Up': 'pushup',
+  Plank: 'plank',
+};
+
+const EXERCISE_KEY_BY_ID: Record<number, string> = {
+  1: 'pushup',
+  2: 'squat',
+  3: 'lunge',
+  4: 'plank',
 };
 
 const EXERCISE_EMOJI: Record<string, string> = {
@@ -88,7 +99,7 @@ function goalContextToLocalGoals(
 function fromApiItem(item: ExerciseGoalSummaryItem): DisplayGoal {
   const unit = item.daily_target_duration != null ? '초' : '개';
   const target = item.daily_target_count ?? item.daily_target_duration ?? 0;
-  const key = EXERCISE_KEY_MAP[item.exercise_name] ?? '';
+  const key = EXERCISE_KEY_BY_ID[item.exercise_id] ?? EXERCISE_KEY_MAP[item.exercise_name] ?? '';
   const apiGoalId = item.goal_id ?? goalIdStorage.get(item.exercise_id);
   if (item.goal_id != null) goalIdStorage.set(item.exercise_id, item.goal_id);
   return {
@@ -118,7 +129,7 @@ function fromLocalGoal(g: LocalExerciseGoal, idx: number): DisplayGoal {
 
 export function MyPage() {
   const navigate = useNavigate();
-  const { goal: goalCtx, updateGoal } = useGoal();
+  const { goal: goalCtx, updateGoal, resetCalibrated } = useGoal();
 
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
   const [displayGoals, setDisplayGoals] = useState<DisplayGoal[]>([]);
@@ -134,7 +145,8 @@ export function MyPage() {
 
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
   const [loggingOut, setLoggingOut] = useState(false);
-  const [resetTarget, setResetTarget] = useState<string | null>(null);
+  const [resetTarget, setResetTarget] = useState<DisplayGoal | null>(null);
+  const [resettingThreshold, setResettingThreshold] = useState(false);
   const [bodyData, setBodyData] = useState<BodyData | null>(() => bodyStorage.load());
 
   const loadData = useCallback(async () => {
@@ -293,6 +305,39 @@ export function MyPage() {
       setLoggingOut(false);
       setShowLogoutConfirm(false);
       navigate('/');
+    }
+  };
+
+  const openThresholdReset = (goal: DisplayGoal) => {
+    setResetTarget(goal);
+  };
+
+  const handleThresholdReset = async () => {
+    if (!resetTarget) return;
+
+    setResettingThreshold(true);
+    try {
+      let goalId = resetTarget.api_goal_id ?? goalIdStorage.get(resetTarget.exercise_id);
+      if (goalId == null) {
+        const summary = await userApi.getSummary();
+        const latestGoal = summary.exercise_goals.find(
+          (goal) => goal.exercise_id === resetTarget.exercise_id,
+        );
+        goalId = latestGoal?.goal_id ?? null;
+        if (goalId != null) goalIdStorage.set(resetTarget.exercise_id, goalId);
+      }
+      if (goalId == null) return;
+
+      const resetGoal = await userApi.resetExerciseGoalThreshold(goalId);
+      const resetExerciseKey =
+        EXERCISE_KEY_BY_ID[resetGoal.exercise_id] ?? resetTarget.key;
+      if (resetExerciseKey) resetCalibrated(resetExerciseKey);
+      setResetTarget(null);
+      await loadData();
+    } catch {
+      // Keep the confirmation sheet open so the user can retry.
+    } finally {
+      setResettingThreshold(false);
     }
   };
 
@@ -469,7 +514,7 @@ export function MyPage() {
                       <span style={{ color: '#CCCCCC', fontSize: 14 }}>{g.exercise_name}</span>
                     </div>
                     <button
-                      onClick={() => setResetTarget(g.exercise_name)}
+                      onClick={() => openThresholdReset(g)}
                       className="flex items-center gap-1.5 px-3 rounded-lg"
                       style={{
                         height: 32,
@@ -538,15 +583,19 @@ export function MyPage() {
 
       {resetTarget && (
         <ConfirmSheet
-          message={`${resetTarget} 임계값을 초기화할까요?`}
+          message={`${resetTarget.exercise_name} 임계값을 초기화할까요?`}
           subMessage="다음 촬영 시 임계값을 다시 측정해야 해요"
           confirmLabel="초기화"
           confirmColor="#FF5A5A"
-          onConfirm={() => setResetTarget(null)}
-          onCancel={() => setResetTarget(null)}
+          onConfirm={handleThresholdReset}
+          onCancel={() => {
+            if (resettingThreshold) return;
+            setResetTarget(null);
+          }}
           icon={<RotateCcw size={24} color="#FF5A5A" />}
           iconBg="rgba(255,90,90,0.12)"
           iconBorder="rgba(255,90,90,0.3)"
+          disabled={resettingThreshold}
         />
       )}
     </div>

--- a/frontend/src/app/features/profile/MyPage.tsx
+++ b/frontend/src/app/features/profile/MyPage.tsx
@@ -147,6 +147,7 @@ export function MyPage() {
   const [loggingOut, setLoggingOut] = useState(false);
   const [resetTarget, setResetTarget] = useState<DisplayGoal | null>(null);
   const [resettingThreshold, setResettingThreshold] = useState(false);
+  const [resetError, setResetError] = useState<string | null>(null);
   const [bodyData, setBodyData] = useState<BodyData | null>(() => bodyStorage.load());
 
   const loadData = useCallback(async () => {
@@ -309,6 +310,7 @@ export function MyPage() {
   };
 
   const openThresholdReset = (goal: DisplayGoal) => {
+    setResetError(null);
     setResetTarget(goal);
   };
 
@@ -316,6 +318,7 @@ export function MyPage() {
     if (!resetTarget) return;
 
     setResettingThreshold(true);
+    setResetError(null);
     try {
       let goalId = resetTarget.api_goal_id ?? goalIdStorage.get(resetTarget.exercise_id);
       if (goalId == null) {
@@ -326,7 +329,10 @@ export function MyPage() {
         goalId = latestGoal?.goal_id ?? null;
         if (goalId != null) goalIdStorage.set(resetTarget.exercise_id, goalId);
       }
-      if (goalId == null) return;
+      if (goalId == null) {
+        setResetError('운동 목표 정보를 찾을 수 없습니다. 잠시 후 다시 시도해주세요.');
+        return;
+      }
 
       const resetGoal = await userApi.resetExerciseGoalThreshold(goalId);
       const resetExerciseKey =
@@ -334,8 +340,12 @@ export function MyPage() {
       if (resetExerciseKey) resetCalibrated(resetExerciseKey);
       setResetTarget(null);
       await loadData();
-    } catch {
-      // Keep the confirmation sheet open so the user can retry.
+    } catch (error) {
+      setResetError(
+        error instanceof Error
+          ? error.message
+          : '임계값 초기화에 실패했습니다. 다시 시도해주세요.',
+      );
     } finally {
       setResettingThreshold(false);
     }
@@ -584,13 +594,14 @@ export function MyPage() {
       {resetTarget && (
         <ConfirmSheet
           message={`${resetTarget.exercise_name} 임계값을 초기화할까요?`}
-          subMessage="다음 촬영 시 임계값을 다시 측정해야 해요"
+          subMessage={resetError ?? '다음 촬영 시 임계값을 다시 측정해야 해요'}
           confirmLabel="초기화"
           confirmColor="#FF5A5A"
           onConfirm={handleThresholdReset}
           onCancel={() => {
             if (resettingThreshold) return;
             setResetTarget(null);
+            setResetError(null);
           }}
           icon={<RotateCcw size={24} color="#FF5A5A" />}
           iconBg="rgba(255,90,90,0.12)"


### PR DESCRIPTION
## Summary

>- #98 

임계값 초기화 버튼 클릭 시 사용자의 임계값이 초기화되고 다음 최초 1회 운동 시 임계값 설정을 진행하도록 API를 구현하고 연동했습니다.

## Tasks

- 운동 목표 임계값 초기화 API 추가
- 마이페이지 임계값 초기화 버튼 API 연동
- 임계값 초기화 시 UserExerciseGoal.threshold를 null로 변경
- 기존 calibration 데이터는 삭제하지 않고 metrics_json = null인 최신 calibration 데이터 추가
- 최신 calibration의 metrics_json이 null이면 임계값 미설정 상태로 처리
- 임계값 초기화 후 운동 시작 시 다시 임계값 설정 화면으로 이동하도록 처리
- Swagger/OpenAPI 문서 반영
- 관련 테스트 추가 및 검증 수행

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 운동 목표의 임계값 초기화 기능이 추가되었습니다.
  * 임계값 초기화 시 사용자 확인 절차가 포함되었습니다.
  * 운동 목표 요약 응답에 목표 ID 정보가 추가되었습니다.

* **버그 수정**
  * 메트릭 데이터 누락 시 캘리브레이션을 미발견 상태로 올바르게 처리하도록 개선되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GYMPT-Advanced-Capstone/GYMPT/pull/99)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->