### PR TITLE
feature/FE-98: 마이페이지 아이콘 변경 및 위치 조정, 렌더링 오류 해결

### DIFF
--- a/frontend/src/app/features/profile/MyPage.tsx
+++ b/frontend/src/app/features/profile/MyPage.tsx
@@ -34,6 +34,10 @@ import {
   type LocalExerciseGoal,
 } from '../../api/userApi';
 import { useGoal } from '../../context/GoalContext';
+import squatImg  from '../../../assets/exercises/squat.png';
+import pushupImg from '../../../assets/exercises/pushup.png';
+import lungeImg  from '../../../assets/exercises/lunge.png';
+import plankImg  from '../../../assets/exercises/plank.png';
 
 type DisplayGoal = {
   key: string;
@@ -71,11 +75,11 @@ const EXERCISE_KEY_BY_ID: Record<number, string> = {
   4: 'plank',
 };
 
-const EXERCISE_EMOJI: Record<string, string> = {
-  squat:  '🦵',
-  lunge:  '🏃',
-  pushup: '💪',
-  plank:  '⏱️',
+const EXERCISE_IMAGE: Record<string, { src: string; scale: number }> = {
+  squat:  { src: squatImg,  scale: 1.2 },
+  lunge:  { src: lungeImg,  scale: 2.0 },
+  pushup: { src: pushupImg, scale: 1.8 },
+  plank:  { src: plankImg,  scale: 1.5 },
 };
 
 const GOAL_CONTEXT_META: Record<string, { name: string; unit: string }> = {
@@ -670,7 +674,7 @@ function GoalRow({ label, value, onEdit, icon }: { label: string; value: string;
 }
 
 function ExerciseGoalRow({ goal: g, onEdit }: { goal: DisplayGoal; onEdit: () => void }) {
-  const emoji = EXERCISE_EMOJI[g.key] ?? '🏋️';
+  const imgEntry = EXERCISE_IMAGE[g.key];
   const todayStr =
     g.today_count > 0 ? `오늘 ${g.today_count}개 완료`
     : g.today_duration > 0 ? `오늘 ${g.today_duration}초 완료`
@@ -680,10 +684,22 @@ function ExerciseGoalRow({ goal: g, onEdit }: { goal: DisplayGoal; onEdit: () =>
     <div className="flex items-center justify-between px-5 py-4" style={{ borderBottom: '1px solid #2C2C30' }}>
       <div className="flex items-center gap-3">
         <div
-          className="flex items-center justify-center rounded-lg"
-          style={{ width: 30, height: 30, backgroundColor: 'rgba(63,253,212,0.08)', border: '1px solid rgba(63,253,212,0.2)', fontSize: 16 }}
+          className="flex items-center justify-center rounded-lg overflow-hidden"
+          style={{
+            width: 30, height: 30,
+            backgroundColor: 'rgba(63,253,212,0.08)',
+            border: '1px solid rgba(63,253,212,0.2)',
+          }}
         >
-          {emoji}
+          {imgEntry ? (
+            <img
+              src={imgEntry.src}
+              alt={g.exercise_name}
+              style={{ width: '100%', height: '100%', objectFit: 'contain', transform: `scale(${imgEntry.scale})` }}
+            />
+          ) : (
+            <Dumbbell size={14} color="#3FFDD4" />
+          )}
         </div>
         <div className="flex flex-col gap-0.5">
           <span style={{ color: '#CCCCCC', fontSize: 14 }}>{g.exercise_name} 목표</span>
@@ -747,7 +763,6 @@ function EditModal({
         className="w-full rounded-t-3xl px-6 pt-5 pb-10"
         style={{ maxWidth: 390, backgroundColor: '#242428', border: '1px solid #3A3A3E' }}
       >
-        <div className="mx-auto mb-5 rounded-full" style={{ width: 40, height: 4, backgroundColor: '#3A3A3E' }} />
         <div className="flex items-center justify-between mb-5">
           <span style={{ color: '#FFFFFF', fontSize: 17, fontWeight: 700 }}>{title}</span>
           <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer' }}>

--- a/frontend/src/app/features/profile/MyPage.tsx
+++ b/frontend/src/app/features/profile/MyPage.tsx
@@ -89,6 +89,21 @@ const GOAL_CONTEXT_META: Record<string, { name: string; unit: string }> = {
   plank:  { name: '플랭크', unit: '초' },
 };
 
+const EXERCISE_DISPLAY_ORDER: Record<string, number> = {
+  squat:  0,
+  pushup: 1,
+  lunge:  2,
+  plank:  3,
+};
+
+function sortGoals(goals: DisplayGoal[]): DisplayGoal[] {
+  return [...goals].sort(
+    (a, b) =>
+      (EXERCISE_DISPLAY_ORDER[a.key] ?? 99) -
+      (EXERCISE_DISPLAY_ORDER[b.key] ?? 99),
+  );
+}
+
 function goalContextToLocalGoals(
   exerciseCounts: Record<string, number>,
 ): LocalExerciseGoal[] {
@@ -101,15 +116,15 @@ function goalContextToLocalGoals(
 }
 
 function fromApiItem(item: ExerciseGoalSummaryItem): DisplayGoal {
+  const key = EXERCISE_KEY_BY_ID[item.exercise_id] ?? EXERCISE_KEY_MAP[item.exercise_name] ?? '';
   const unit = item.daily_target_duration != null ? '초' : '개';
   const target = item.daily_target_count ?? item.daily_target_duration ?? 0;
-  const key = EXERCISE_KEY_BY_ID[item.exercise_id] ?? EXERCISE_KEY_MAP[item.exercise_name] ?? '';
   const apiGoalId = item.goal_id ?? goalIdStorage.get(item.exercise_id);
   if (item.goal_id != null) goalIdStorage.set(item.exercise_id, item.goal_id);
   return {
     key,
     exercise_id: item.exercise_id,
-    exercise_name: item.exercise_name,
+    exercise_name: GOAL_CONTEXT_META[key]?.name ?? item.exercise_name,
     target,
     unit,
     today_count: item.today_count,
@@ -122,7 +137,7 @@ function fromLocalGoal(g: LocalExerciseGoal, idx: number): DisplayGoal {
   return {
     key: g.exercise_key,
     exercise_id: -(idx + 1),
-    exercise_name: g.exercise_name,
+    exercise_name: GOAL_CONTEXT_META[g.exercise_key]?.name ?? g.exercise_name,
     target: g.target,
     unit: g.unit,
     today_count: 0,
@@ -194,7 +209,7 @@ export function MyPage() {
       }
 
       if (summary && summary.exercise_goals.length > 0) {
-        const goals = summary.exercise_goals.map(fromApiItem);
+        const goals = sortGoals(summary.exercise_goals.map(fromApiItem));
         setDisplayGoals(goals);
         const syncCounts: Record<string, number> = {};
         goals.forEach((g) => { if (g.key) syncCounts[g.key] = g.target; });
@@ -202,13 +217,13 @@ export function MyPage() {
       } else {
         const localGoals = localExerciseGoalStorage.load();
         if (localGoals.length > 0) {
-          setDisplayGoals(localGoals.map(fromLocalGoal));
+          setDisplayGoals(sortGoals(localGoals.map(fromLocalGoal)));
         } else {
           const ctxGoals = goalContextToLocalGoals(goalCtx.exerciseCounts);
           const hasRealData = Object.values(goalCtx.exerciseCounts).some((v) => v > 0);
           if (hasRealData) {
             localExerciseGoalStorage.save(goalCtx.exerciseCounts);
-            setDisplayGoals(ctxGoals.map(fromLocalGoal));
+            setDisplayGoals(sortGoals(ctxGoals.map(fromLocalGoal)));
           }
         }
       }

--- a/frontend/src/app/features/workout/MainPage.tsx
+++ b/frontend/src/app/features/workout/MainPage.tsx
@@ -55,7 +55,7 @@ const weeklyData = [
 ];
 
 const badges = [
-  { icon: '🔥', label: '3일 연속', active: true },
+  { icon: '🔥', label: '3회 달성', active: true },
   { icon: '⚡', label: '첫 분석', active: true },
   { icon: '🏆', label: '주간 달성', active: false },
   { icon: '💎', label: '완벽 자세', active: false },


### PR DESCRIPTION
## Summary

>- 관련 있는 Issue를 태그해주세요.
Closes #100 

**해당 PR에 대한 요약을 작성해주세요.**
마이페이지의 운동 목표 설정에서 운동별 아이콘을 3D 아이콘으로 변경 후에 테두리 크기는
유지하면서 안에 있는 사진 크기만 각각 조절하고 클라이언트 환경별 프로젝트 실행 화면 불일치 오류 해결.

## Tasks
- [x] 마이페이지 운동 목표 설정의 운동별 아이콘 교체
- [x] 운동별로 아이콘 크기 다르게 조절
- [x] 클라이언트 환경별 프로젝트 실행 화면 불일치 오류 해결

## To Reviewer
마이페이지 각자 실행해보았을 때 뭔가 이상하거나 영어로 뜨면 말씀해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 운동 아이콘이 이모지에서 이미지로 표시되도록 변경되었습니다.
  * 운동 목표 목록이 일관된 순서로 정렬되어 표시됩니다.
  * 아이콘별 스케일링이 적용되었습니다.
  * 성취 배지 라벨이 "3일 연속"에서 "3회 달성"으로 업데이트되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GYMPT-Advanced-Capstone/GYMPT/pull/101)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->