### PR TITLE
fix/BE-101: 비밀번호 재설정 흐름 2-step 분리

### DIFF
--- a/backend/app/auth/dto/auth_request.py
+++ b/backend/app/auth/dto/auth_request.py
@@ -72,7 +72,7 @@ class PasswordResetRequest(BaseModel):
     )
 
 
-class PasswordResetConfirmRequest(BaseModel):
+class PasswordResetVerifyRequest(BaseModel):
     email: EmailStr = Field(
         ...,
         description="이메일",
@@ -83,6 +83,14 @@ class PasswordResetConfirmRequest(BaseModel):
         pattern=r"^\d{6}$",
         description="이메일로 받은 6자리 인증 코드",
         json_schema_extra={"example": "123456"},
+    )
+
+
+class PasswordResetConfirmRequest(BaseModel):
+    email: EmailStr = Field(
+        ...,
+        description="이메일",
+        json_schema_extra={"example": "user@example.com"},
     )
     new_password: str = Field(
         ...,

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -17,6 +17,7 @@ from app.auth.dto.auth_request import (
     LogoutRequest,
     PasswordResetConfirmRequest,
     PasswordResetRequest,
+    PasswordResetVerifyRequest,
     SignupRequest,
     TokenRefreshRequest,
 )
@@ -282,12 +283,14 @@ def request_password_reset(data: PasswordResetRequest, db: Session = Depends(get
 
 
 @router.post(
-    "/password-reset",
+    "/password-reset/verify-code",
     status_code=status.HTTP_204_NO_CONTENT,
-    summary="비밀번호 재설정",
-    description="인증 코드 확인 후 비밀번호를 재설정합니다.",
+    summary="비밀번호 재설정 인증 코드 확인",
+    description="비밀번호 재설정을 위한 인증 코드를 확인합니다.",
 )
-def reset_password(data: PasswordResetConfirmRequest, db: Session = Depends(get_db)):
+def verify_password_reset_code(
+    data: PasswordResetVerifyRequest, db: Session = Depends(get_db)
+):
     user = db.query(User).filter(User.email == data.email).first()
     if not user:
         raise HTTPException(
@@ -300,7 +303,35 @@ def reset_password(data: PasswordResetConfirmRequest, db: Session = Depends(get_
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="인증 코드가 올바르지 않거나 만료되었습니다.",
         )
+    store_email_verified(data.email)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post(
+    "/password-reset",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="비밀번호 재설정",
+    description="이메일 인증 완료 후 비밀번호를 재설정합니다.",
+)
+def reset_password(data: PasswordResetConfirmRequest, db: Session = Depends(get_db)):
+    user = db.query(User).filter(User.email == data.email).first()
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="존재하지 않는 사용자입니다.",
+        )
+    if not is_email_verified(data.email):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="이메일 인증이 완료되지 않았습니다.",
+        )
     user.pw = get_password_hash(data.new_password)  # type: ignore[assignment]
     db.commit()
+    try:
+        delete_email_verified(data.email)
+    except Exception:
+        logger.warning(
+            f"Redis cleanup failed for {mask_email(data.email)} after password reset"
+        )
     invalidate_user_session(data.email)
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -692,8 +692,8 @@ def test_request_password_reset_user_not_found(client):
     assert response.json()["detail"] == "등록되지 않은 이메일입니다."
 
 
-# Password Reset
-def test_reset_password_success(client, mock_redis_client):
+# Password Reset Verify Code
+def test_verify_password_reset_code_success(client, mock_redis_client):
     test_client, mock_db = client
     fake_user = User(
         id=1, email="test@test.com", pw="password", name="최인규", nickname="테스터"
@@ -702,20 +702,16 @@ def test_reset_password_success(client, mock_redis_client):
     mock_redis_client.get.return_value = "123456"
 
     response = test_client.post(
-        "/api/v1/auth/password-reset",
-        json={
-            "email": "test@test.com",
-            "code": "123456",
-            "new_password": "newpassword",
-        },
+        "/api/v1/auth/password-reset/verify-code",
+        json={"email": "test@test.com", "code": "123456"},
     )
 
     assert response.status_code == 204
-    mock_redis_client.delete.assert_any_call("EMAIL_CODE:test@test.com")
-    mock_redis_client.delete.assert_any_call("RT:test@test.com")
+    mock_redis_client.delete.assert_called_with("EMAIL_CODE:test@test.com")
+    mock_redis_client.setex.assert_called()
 
 
-def test_reset_password_invalid_code(client, mock_redis_client):
+def test_verify_password_reset_code_invalid(client, mock_redis_client):
     test_client, mock_db = client
     mock_db.query.return_value.filter.return_value.first.return_value = MagicMock(
         id=1, email="test@test.com", pw="hashed_password"
@@ -723,30 +719,71 @@ def test_reset_password_invalid_code(client, mock_redis_client):
     mock_redis_client.get.return_value = "123456"
 
     response = test_client.post(
-        "/api/v1/auth/password-reset",
-        json={
-            "email": "test@test.com",
-            "code": "000000",
-            "new_password": "newpassword",
-        },
+        "/api/v1/auth/password-reset/verify-code",
+        json={"email": "test@test.com", "code": "000000"},
     )
 
     assert response.status_code == 400
     assert response.json()["detail"] == "인증 코드가 올바르지 않거나 만료되었습니다."
 
 
-def test_reset_password_user_not_found(client, mock_redis_client):
+def test_verify_password_reset_code_user_not_found(client, mock_redis_client):
     test_client, mock_db = client
     mock_db.query.return_value.filter.return_value.first.return_value = None
-    mock_redis_client.get.return_value = "123456"
+
+    response = test_client.post(
+        "/api/v1/auth/password-reset/verify-code",
+        json={"email": "test@test.com", "code": "123456"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "존재하지 않는 사용자입니다."
+
+
+# Password Reset
+def test_reset_password_success(client, mock_redis_client):
+    test_client, mock_db = client
+    fake_user = User(
+        id=1, email="test@test.com", pw="password", name="최인규", nickname="테스터"
+    )
+    mock_db.query.return_value.filter.return_value.first.return_value = fake_user
+    mock_redis_client.get.side_effect = lambda key: (
+        "1" if key == "VERIFIED:test@test.com" else None
+    )
 
     response = test_client.post(
         "/api/v1/auth/password-reset",
-        json={
-            "email": "test@test.com",
-            "code": "123456",
-            "new_password": "newpassword",
-        },
+        json={"email": "test@test.com", "new_password": "newpassword"},
+    )
+
+    assert response.status_code == 204
+    mock_redis_client.delete.assert_any_call("VERIFIED:test@test.com")
+    mock_redis_client.delete.assert_any_call("RT:test@test.com")
+
+
+def test_reset_password_without_verify(client, mock_redis_client):
+    test_client, mock_db = client
+    mock_db.query.return_value.filter.return_value.first.return_value = MagicMock(
+        id=1, email="test@test.com", pw="hashed_password"
+    )
+    mock_redis_client.get.return_value = None
+
+    response = test_client.post(
+        "/api/v1/auth/password-reset",
+        json={"email": "test@test.com", "new_password": "newpassword"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "이메일 인증이 완료되지 않았습니다."
+
+
+def test_reset_password_user_not_found(client, mock_redis_client):
+    test_client, mock_db = client
+    mock_db.query.return_value.filter.return_value.first.return_value = None
+
+    response = test_client.post(
+        "/api/v1/auth/password-reset",
+        json={"email": "test@test.com", "new_password": "newpassword"},
     )
 
     assert response.status_code == 404

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -740,6 +740,23 @@ def test_verify_password_reset_code_user_not_found(client, mock_redis_client):
     assert response.json()["detail"] == "존재하지 않는 사용자입니다."
 
 
+def test_verify_password_reset_code_redis_error(client, mock_redis_client):
+    test_client, mock_db = client
+    fake_user = User(
+        id=1, email="test@test.com", pw="password", name="최인규", nickname="테스터"
+    )
+    mock_db.query.return_value.filter.return_value.first.return_value = fake_user
+    mock_redis_client.get.side_effect = redis.RedisError("connection error")
+
+    response = test_client.post(
+        "/api/v1/auth/password-reset/verify-code",
+        json={"email": "test@test.com", "code": "123456"},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "인증 서버에 일시적인 오류가 발생했습니다."
+
+
 # Password Reset
 def test_reset_password_success(client, mock_redis_client):
     test_client, mock_db = client

--- a/frontend/src/app/api/authApi.ts
+++ b/frontend/src/app/api/authApi.ts
@@ -180,9 +180,15 @@ export const authApi = {
       body: JSON.stringify({ email }),
     }),
 
-  resetPassword: (email: string, code: string, newPassword: string) =>
+  verifyPasswordResetCode: (email: string, code: string) =>
+    request<void>('/api/v1/auth/password-reset/verify-code', {
+      method: 'POST',
+      body: JSON.stringify({ email, code }),
+    }),
+
+  resetPassword: (email: string, newPassword: string) =>
     request<void>('/api/v1/auth/password-reset', {
       method: 'POST',
-      body: JSON.stringify({ email, code, new_password: newPassword }),
+      body: JSON.stringify({ email, new_password: newPassword }),
     }),
 };

--- a/frontend/src/app/features/auth/FindPasswordPage.tsx
+++ b/frontend/src/app/features/auth/FindPasswordPage.tsx
@@ -118,11 +118,10 @@ export function FindPasswordPage() {
     } catch (err) {
       const message = err instanceof Error ? err.message : '비밀번호 재설정에 실패했어요.';
       if (
-        message.toLowerCase().includes('invalid') ||
-        message.toLowerCase().includes('expired') ||
-        message.toLowerCase().includes('code')
+        message.toLowerCase().includes('verified') ||
+        message.toLowerCase().includes('expired')
       ) {
-        setResetError('인증 코드가 올바르지 않거나 만료되었어요. 처음부터 다시 시도해주세요.');
+        setResetError('인증이 만료되었어요. 처음부터 다시 시도해주세요.');
       } else {
         setResetError(message);
       }

--- a/frontend/src/app/features/auth/FindPasswordPage.tsx
+++ b/frontend/src/app/features/auth/FindPasswordPage.tsx
@@ -43,16 +43,18 @@ export function FindPasswordPage() {
   const [showConfirm, setShowConfirm] = useState(false);
 
   const [loadingSend, setLoadingSend] = useState(false);
+  const [loadingVerify, setLoadingVerify] = useState(false);
   const [loadingReset, setLoadingReset] = useState(false);
 
   const [sendError, setSendError] = useState('');
+  const [verifyError, setVerifyError] = useState('');
   const [resetError, setResetError] = useState('');
 
   const isEmailValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
   const pwValid = newPw.length >= 8;
   const pwMatch = newPw === confirmPw && confirmPw.length > 0;
 
-  const verifyReady = codeSent && code.trim().length === 6;
+  const verifyReady = codeSent && code.trim().length === 6 && !loadingVerify;
   const resetReady = pwValid && pwMatch && !loadingReset;
 
   const handleSendCode = async () => {
@@ -80,10 +82,29 @@ export function FindPasswordPage() {
     }
   };
 
-  const handleVerify = () => {
+  const handleVerify = async () => {
     if (!verifyReady) return;
+    setVerifyError('');
     setResetError('');
-    setStep('reset');
+    setLoadingVerify(true);
+
+    try {
+      await authApi.verifyPasswordResetCode(email.trim(), code.trim());
+      setStep('reset');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '인증 코드 확인에 실패했어요.';
+      if (
+        message.toLowerCase().includes('invalid') ||
+        message.toLowerCase().includes('expired') ||
+        message.toLowerCase().includes('code')
+      ) {
+        setVerifyError('인증 코드가 올바르지 않거나 만료되었어요.');
+      } else {
+        setVerifyError(message);
+      }
+    } finally {
+      setLoadingVerify(false);
+    }
   };
 
   const handleReset = async () => {
@@ -92,7 +113,7 @@ export function FindPasswordPage() {
     setLoadingReset(true);
 
     try {
-      await authApi.resetPassword(email.trim(), code.trim(), newPw);
+      await authApi.resetPassword(email.trim(), newPw);
       setStep('done');
     } catch (err) {
       const message = err instanceof Error ? err.message : '비밀번호 재설정에 실패했어요.';
@@ -275,6 +296,7 @@ export function FindPasswordPage() {
                         setCodeSent(false);
                         setCode('');
                         setSendError('');
+                        setVerifyError('');
                       }}
                       style={{
                         flex: 1,
@@ -324,61 +346,74 @@ export function FindPasswordPage() {
               </div>
 
               {codeSent && (
-                <div className="flex items-center gap-2" style={{ marginBottom: 32, width: '100%' }}>
-                  <div
-                    className="flex items-center gap-3 px-4"
-                    style={{
-                      flex: 1,
-                      minWidth: 0,
-                      backgroundColor: '#2C2C30',
-                      borderRadius: 12,
-                      height: 54,
-                      border: `1px solid ${code.trim() ? 'rgba(63,253,212,0.4)' : '#3A3A3E'}`,
-                      transition: 'border-color 0.2s',
-                    }}
-                  >
-                    <input
-                      type="text"
-                      placeholder="인증번호 6자리를 입력해주세요"
-                      value={code}
-                      maxLength={6}
-                      onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+                <div style={{ marginBottom: 32 }}>
+                  <div className="flex items-center gap-2" style={{ width: '100%' }}>
+                    <div
+                      className="flex items-center gap-3 px-4"
                       style={{
                         flex: 1,
                         minWidth: 0,
-                        background: 'transparent',
-                        border: 'none',
-                        outline: 'none',
-                        color: '#FFFFFF',
-                        fontSize: 15,
-                        letterSpacing: code ? 4 : 0,
+                        backgroundColor: '#2C2C30',
+                        borderRadius: 12,
+                        height: 54,
+                        border: `1px solid ${code.trim() ? 'rgba(63,253,212,0.4)' : '#3A3A3E'}`,
+                        transition: 'border-color 0.2s',
                       }}
-                      className="placeholder-[#555555]"
-                    />
-                    {code.length === 6 && (
-                      <span style={{ color: '#3FFDD4', fontSize: 12, fontWeight: 600, flexShrink: 0 }}>✓</span>
-                    )}
+                    >
+                      <input
+                        type="text"
+                        placeholder="인증번호 6자리를 입력해주세요"
+                        value={code}
+                        maxLength={6}
+                        onChange={(e) => {
+                          setCode(e.target.value.replace(/\D/g, '').slice(0, 6));
+                          setVerifyError('');
+                        }}
+                        style={{
+                          flex: 1,
+                          minWidth: 0,
+                          background: 'transparent',
+                          border: 'none',
+                          outline: 'none',
+                          color: '#FFFFFF',
+                          fontSize: 15,
+                          letterSpacing: code ? 4 : 0,
+                        }}
+                        className="placeholder-[#555555]"
+                      />
+                      {code.length === 6 && (
+                        <span style={{ color: '#3FFDD4', fontSize: 12, fontWeight: 600, flexShrink: 0 }}>✓</span>
+                      )}
+                    </div>
+                    <button
+                      onClick={handleVerify}
+                      disabled={!verifyReady}
+                      style={{
+                        flexShrink: 0,
+                        width: 80,
+                        height: 54,
+                        borderRadius: 12,
+                        border: `1.5px solid ${verifyReady ? '#3FFDD4' : '#3A3A3E'}`,
+                        backgroundColor: 'transparent',
+                        color: verifyReady ? '#3FFDD4' : '#555555',
+                        fontSize: 13,
+                        fontWeight: 700,
+                        cursor: verifyReady ? 'pointer' : 'not-allowed',
+                        whiteSpace: 'nowrap',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        gap: 4,
+                        transition: 'color 0.2s, border-color 0.2s',
+                      }}
+                    >
+                      {loadingVerify ? <Spinner /> : null}
+                      인증 확인
+                    </button>
                   </div>
-                  <button
-                    onClick={handleVerify}
-                    disabled={!verifyReady}
-                    style={{
-                      flexShrink: 0,
-                      width: 80,
-                      height: 54,
-                      borderRadius: 12,
-                      border: `1.5px solid ${verifyReady ? '#3FFDD4' : '#3A3A3E'}`,
-                      backgroundColor: 'transparent',
-                      color: verifyReady ? '#3FFDD4' : '#555555',
-                      fontSize: 13,
-                      fontWeight: 700,
-                      cursor: verifyReady ? 'pointer' : 'not-allowed',
-                      whiteSpace: 'nowrap',
-                      transition: 'color 0.2s, border-color 0.2s',
-                    }}
-                  >
-                    인증 확인
-                  </button>
+                  {verifyError && (
+                    <p style={{ color: '#FF6B6B', fontSize: 12, marginTop: 6 }}>{verifyError}</p>
+                  )}
                 </div>
               )}
             </>


### PR DESCRIPTION
## Summary

>- Closes #106 

비밀번호 재설정 흐름을 회원가입과 동일한 2-step 구조(인증 코드 확인 + 비밀번호 변경)로 분리

## Tasks

- POST /api/v1/auth/password-reset/verify-code 신규 (코드 검증 + VERIFIED 플래그)
- POST /api/v1/auth/password-reset 수정 (코드 검증 제거, is_email_verified 체크)
- PasswordResetVerifyRequest DTO 추가, PasswordResetConfirmRequest에서 code 필드 제거
- 백엔드 테스트 추가/수정
- authApi.verifyPasswordResetCode 함수 추가, resetPassword 시그니처 정리
- FindPasswordPage handleVerify async 전환 + 인증 API 연동
- 인증 코드 검증 로딩/에러 상태 처리 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 비밀번호 재설정 흐름이 개선되어 인증 코드 검증과 비밀번호 변경이 별도의 단계로 분리되었습니다.
  * 코드 검증 후 새 비밀번호를 설정하는 두 단계 프로세스로 진행됩니다.

* **버그 수정**
  * 인증되지 않은 상태에서의 비밀번호 변경 시도에 대한 접근 제어가 강화되었습니다.

* **개선사항**
  * 비동기 요청 중 중복 요청 방지 및 에러 처리가 개선되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GYMPT-Advanced-Capstone/GYMPT/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->