### PR TITLE
[BE-103] 운동결과 이상적 신체 각도 API구현

### DIFF
--- a/backend/app/exercise_record/dto/exercise_record_request.py
+++ b/backend/app/exercise_record/dto/exercise_record_request.py
@@ -111,6 +111,13 @@ class ExerciseRecordCreateRequest(BaseModel):
         default=None,
         description="AI 피드백 생성에 사용할 반복별 자세 분석 데이터",
     )
+    best_rep_metrics: dict[str, Any] | None = Field(
+        default=None,
+        description="이상값에 가장 가까운 렙의 관절 측정값",
+        json_schema_extra={
+            "example": {"bottomKneeAngle": 86.2, "bottomHipAngle": 79.1}
+        },
+    )
 
     @field_validator("count", "duration")
     @classmethod

--- a/backend/app/exercise_record/dto/exercise_record_response.py
+++ b/backend/app/exercise_record/dto/exercise_record_response.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from decimal import Decimal
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -46,6 +47,11 @@ class ExerciseRecordResponse(BaseModel):
         default=None,
         description="AI가 생성한 운동 자세 최종 피드백",
         json_schema_extra={"example": "전반적으로 안정적인 자세를 유지했습니다."},
+    )
+    best_rep_metrics: dict[str, Any] | None = Field(
+        default=None,
+        description="이상값에 가장 가까운 렙의 관절 측정값",
+        json_schema_extra={"example": {"bottomKneeAngle": 86.2, "bottomHipAngle": 79.1}},
     )
 
 

--- a/backend/app/exercise_record/dto/exercise_record_response.py
+++ b/backend/app/exercise_record/dto/exercise_record_response.py
@@ -51,7 +51,9 @@ class ExerciseRecordResponse(BaseModel):
     best_rep_metrics: dict[str, Any] | None = Field(
         default=None,
         description="이상값에 가장 가까운 렙의 관절 측정값",
-        json_schema_extra={"example": {"bottomKneeAngle": 86.2, "bottomHipAngle": 79.1}},
+        json_schema_extra={
+            "example": {"bottomKneeAngle": 86.2, "bottomHipAngle": 79.1}
+        },
     )
 
 

--- a/backend/app/exercise_record/exercise_record_model.py
+++ b/backend/app/exercise_record/exercise_record_model.py
@@ -28,6 +28,7 @@ class ExerciseRecord(Base):
     calories = Column(DECIMAL(6, 2), nullable=False)  # type: ignore[var-annotated]
     completed_at = Column(DateTime, nullable=False, default=func.now())
     ai_feedback = Column(Text, nullable=True)
+    best_rep_metrics = Column(JSON, nullable=True)
 
     exercise = relationship("Exercise", back_populates="records")
 

--- a/backend/app/exercise_record/exercise_record_service.py
+++ b/backend/app/exercise_record/exercise_record_service.py
@@ -31,6 +31,7 @@ class ExerciseRecordService:
             duration=data.duration,
             calories=data.calories,
             completed_at=data.completed_at,
+            best_rep_metrics=data.best_rep_metrics,
         )
         created_record = self.repo.create(record)
 
@@ -98,4 +99,5 @@ class ExerciseRecordService:
             calories=cast(Decimal, record.calories),
             completed_at=cast(datetime, record.completed_at),
             ai_feedback=cast(str | None, record.ai_feedback),
+            best_rep_metrics=record.best_rep_metrics,
         )

--- a/backend/app/exercise_record/exercise_record_service.py
+++ b/backend/app/exercise_record/exercise_record_service.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 from decimal import Decimal
-from typing import cast
+from typing import Any, cast
 
 from fastapi import HTTPException, status
 
@@ -99,5 +99,5 @@ class ExerciseRecordService:
             calories=cast(Decimal, record.calories),
             completed_at=cast(datetime, record.completed_at),
             ai_feedback=cast(str | None, record.ai_feedback),
-            best_rep_metrics=record.best_rep_metrics,
+            best_rep_metrics=cast(dict[str, Any] | None, record.best_rep_metrics),
         )

--- a/backend/tests/exercise/test_exercise_record.py
+++ b/backend/tests/exercise/test_exercise_record.py
@@ -35,6 +35,7 @@ def make_record(
     calories: Decimal = Decimal("13.50"),
     completed_at: datetime = datetime(2026, 3, 26, 10, 30, 0),
     ai_feedback: str | None = None,
+    best_rep_metrics: dict | None = None,
 ):
     return SimpleNamespace(
         id=record_id,
@@ -46,6 +47,7 @@ def make_record(
         calories=calories,
         completed_at=completed_at,
         ai_feedback=ai_feedback,
+        best_rep_metrics=best_rep_metrics,
     )
 
 
@@ -64,6 +66,8 @@ class FakeExerciseRecordRepo:
             id=record.exercise_id, name="Push Up", description=None
         )
         record.ai_feedback = None
+        if not hasattr(record, "best_rep_metrics"):
+            record.best_rep_metrics = None
         self.created_record = record
         return record
 

--- a/frontend/src/app/api/workoutApi.ts
+++ b/frontend/src/app/api/workoutApi.ts
@@ -30,6 +30,7 @@ export interface ExerciseRecordResponse {
   calories: string;
   completed_at: string;
   ai_feedback?: string | null;
+  best_rep_metrics?: Record<string, number> | null;
 }
 
 export const workoutApi = {
@@ -67,6 +68,7 @@ export const workoutApi = {
       exercise_type?: string;
       reps: ExerciseRecordRepRequest[];
     };
+    best_rep_metrics?: Record<string, number> | null;
   }) =>
     request<ExerciseRecordResponse>(
       "/api/exercise-records",

--- a/frontend/src/app/features/analysis/AnalysisPage.tsx
+++ b/frontend/src/app/features/analysis/AnalysisPage.tsx
@@ -31,25 +31,15 @@ interface ExerciseRecord {
   score: number;
   accuracy_avg: string;
   completed_at: string;
-  analysis?: {
-    range_score?: number;
-    extension_score?: number;
-    stability_score?: number;
-    exercise_type?: string;
-    reps?: {
-      rep_index?: number;
-      metrics?: {
-        bodyLineAngle?: number;
-        bottomElbowAngle?: number;
-        topElbowAngle?: number;
-      };
-    }[];
-    range_summary?: {
-      bodyStabilityRate?: number;
-      rangeCompletionRate?: number;
-      topExtensionRate?: number;
-    };
-  };
+  best_rep_metrics?: {
+    bottomKneeAngle?: number;
+    bottomHipAngle?: number;
+    bottomElbowAngle?: number;
+    bodyLineAngle?: number;
+    topKneeAngle?: number;
+    topElbowAngle?: number;
+    [key: string]: number | undefined;
+  } | null;
 }
 
 interface UserGoal {
@@ -312,38 +302,17 @@ export function AnalysisPage() {
         let userAngle2 = 0;
 
         if (matchingRecord) {
-          const reps = matchingRecord.analysis?.reps;
-          
-          // 1. 실제 회차별 실시간 데이터(reps)가 있으면 하나씩 더해 평균 각도 구하기
-          if (Array.isArray(reps) && reps.length > 0) {
-            let sum1 = 0, count1 = 0;
-            let sum2 = 0, count2 = 0;
+          const bm = matchingRecord.best_rep_metrics;
 
-            reps.forEach((rep) => {
-              const m = rep.metrics;
-              if (!m) return;
-
-              if (koName === "푸쉬업") {
-                if (m.bottomElbowAngle) { sum1 += m.bottomElbowAngle; count1++; }
-                if (m.bodyLineAngle) { sum2 += m.bodyLineAngle; count2++; }
-              } else if (koName === "스쿼트" || koName === "런지") {
-                const angle = m.bottomElbowAngle ?? m.topElbowAngle;
-                if (angle) { sum1 += angle; count1++; }
-              } else if (koName === "플랭크") {
-                if (m.bodyLineAngle) { sum1 += m.bodyLineAngle; count1++; }
-              }
-            });
-
-            userAngle = count1 > 0 ? Math.round(sum1 / count1) : 0;
-            userAngle2 = count2 > 0 ? Math.round(sum2 / count2) : 0;
-          }
-
-          // 2. 만약 reps 내부 세부 metric 필드가 비어있다면, 당일의 전반적인 score나 accuracy_avg를 대용값으로 실시간 반영
-          if (userAngle === 0) {
-            userAngle = matchingRecord.score || Number(matchingRecord.accuracy_avg) || 0;
-          }
-          if (koName === "푸쉬업" && userAngle2 === 0) {
-            userAngle2 = 165; // 푸쉬업 엉덩이 수평 기본 백업 값
+          if (bm) {
+            if (koName === "푸쉬업") {
+              userAngle = Math.round(bm.bottomElbowAngle ?? 0);
+              userAngle2 = Math.round(bm.bodyLineAngle ?? 0);
+            } else if (koName === "스쿼트" || koName === "런지") {
+              userAngle = Math.round(bm.bottomKneeAngle ?? 0);
+            } else if (koName === "플랭크") {
+              userAngle = Math.round(bm.bodyLineAngle ?? 0);
+            }
           }
         }
 

--- a/frontend/src/app/features/analysis/AnalysisPage.tsx
+++ b/frontend/src/app/features/analysis/AnalysisPage.tsx
@@ -407,7 +407,7 @@ export function AnalysisPage() {
         dailyRecords.length > 0
           ? Math.round(
               dailyRecords.reduce((acc, record) => {
-                const metrics = record.analysis?.reps?.[0]?.metrics;
+                const metrics = record.best_rep_metrics;
                 if (!metrics) {
                   return acc + (record.score || Number(record.accuracy_avg) || 80);
                 }

--- a/frontend/src/app/features/analysis/AnalysisPage.tsx
+++ b/frontend/src/app/features/analysis/AnalysisPage.tsx
@@ -85,8 +85,15 @@ export function AnalysisPage() {
   // 💡 [핵심] 선택한 날짜 기준 앞뒤 2일(총 5일)의 실제 데이터를 저장할 공간
   const [fiveDaysRecords, setFiveDaysRecords] = useState<{ [dateStr: string]: ExerciseRecord[] }>({});
   
-  const [userGoal, setUserGoal] = useState<UserGoal | null>(null);
-  const [userName, setUserName] = useState("사용자");
+  const userGoal = useMemo<UserGoal | null>(() => {
+    try {
+      const saved = localStorage.getItem("gympt_goal");
+      return saved ? (JSON.parse(saved) as UserGoal) : null;
+    } catch {
+      return null;
+    }
+  }, []);
+  const userName = localStorage.getItem("gympt_user_name") ?? "사용자";
   const [weeklyCalories, setWeeklyCalories] = useState("0.0");
 
   const viewYear = currentDate.getFullYear();
@@ -97,18 +104,6 @@ export function AnalysisPage() {
     if (!token) {
       alert("로그인이 만료되었습니다. 다시 로그인해주세요.");
       navigate("/");
-      return;
-    }
-    const savedName = localStorage.getItem("gympt_user_name");
-    const savedGoal = localStorage.getItem("gympt_goal");
-    if (savedName) setUserName(savedName);
-    if (savedGoal) {
-      try {
-        const parsedGoal = JSON.parse(savedGoal) as UserGoal;
-        setUserGoal(parsedGoal);
-      } catch (error) {
-        console.error("goal parsing error:", error);
-      }
     }
   }, [navigate]);
 

--- a/frontend/src/app/features/workout/CameraAnalysisPage.tsx
+++ b/frontend/src/app/features/workout/CameraAnalysisPage.tsx
@@ -17,6 +17,37 @@ import { buildPushupObservation } from "./utils/pushup";
 
 const SQUAT_KCAL_PER_REP = 0.32;
 
+const IDEAL_METRICS: Record<string, Record<string, number>> = {
+  squat: { bottomKneeAngle: 85 },
+  pushup: { bottomElbowAngle: 55, bodyLineAngle: 180 },
+};
+
+function pickBestRepMetrics(
+  exerciseType: string,
+  repSummaries: { metrics: Record<string, number> }[],
+): Record<string, number> | null {
+  if (repSummaries.length === 0) return null;
+  const ideal = IDEAL_METRICS[exerciseType];
+  if (!ideal) return repSummaries[0].metrics;
+
+  let bestMetrics = repSummaries[0].metrics;
+  let bestScore = Infinity;
+
+  for (const rep of repSummaries) {
+    let score = 0;
+    for (const [key, idealVal] of Object.entries(ideal)) {
+      const actual = rep.metrics[key] ?? idealVal;
+      score += Math.abs(actual - idealVal);
+    }
+    if (score < bestScore) {
+      bestScore = score;
+      bestMetrics = rep.metrics;
+    }
+  }
+
+  return bestMetrics;
+}
+
 const TEXT = {
   finishWorkout: "운동 종료",
   feedbackTitle: "AI 실시간 피드백",
@@ -191,6 +222,8 @@ export function CameraAnalysisPage() {
 
     try {
       setIsSavingResult(true);
+      const bestRepMetrics = pickBestRepMetrics(resolvedExerciseId, repSummaries);
+
       const response = await workoutApi.createExerciseRecord({
         exercise_id: exercise.backendExerciseId,
         count: currentAnalysis.fullRepCount,
@@ -205,6 +238,7 @@ export function CameraAnalysisPage() {
             representative_feedback_code: rep.representativeFeedbackCode ?? null,
           })),
         },
+        best_rep_metrics: bestRepMetrics,
       });
 
       navigate("/post-workout", {


### PR DESCRIPTION

## Summary

>- Closes #108

**해당 PR에 대한 요약을 작성해주세요.**
운동 세션 종료 시, 해당 세션의 모든 렙 중 이상적인 관절 각도에 가장 가까운 렙의 측정값(best_rep_metrics)을 DB에 저장하고, 분석 페이지 차트에 반영합니다.

## Tasks

 Backend

  - exercise_records 테이블에 best_rep_metrics (JSON, nullable) 컬럼 추가
  - ExerciseRecordCreateRequest / ExerciseRecordResponse DTO에 best_rep_metrics 필드 추가
  - ExerciseRecordService.create() 및 _to_response()에서 해당 필드 처리

  Frontend

  - CameraAnalysisPage: 운동 종료 시 pickBestRepMetrics() 함수로 이상값 기준 최적 렙 선택 후 API 전송
    - 스쿼트: bottomKneeAngle 85° 기준
    - 푸쉬업: bottomElbowAngle 55°, bodyLineAngle 180° 기준
  - AnalysisPage: 차트 데이터를 기존의 존재하지 않는 analysis.reps 필드 대신 best_rep_metrics 기반으로 수정

  Test

  - test_exercise_record.py: make_record() 및 FakeExerciseRecordRepo.create()에 best_rep_metrics 누락 수정

  DB 마이그레이션

  기존 테이블에 컬럼을 수동으로 추가해야 합니다:

  ALTER TABLE exercise_records ADD COLUMN best_rep_metrics JSON NULL;

## To Reviewer

_(없을 경우 삭제) 더 전달할 내용이 있다면 여기에 작성해주세요._

## Screenshot

_(없을 경우 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 운동 기록에 각 회차 중 '베스트' 회차의 관절 측정값(각도 등)을 자동으로 선택해 저장합니다.
  * 분석 페이지에서 베스트 리프 기반 메트릭을 사용해 자세 분석의 정확도를 향상시켰습니다.
  * 촬영(카메라) 분석 종료 시 베스트 회차 메트릭을 기록 생성에 포함합니다.
  * 사용자 목표/이름 로딩 방식을 개선해 초기 로딩이 더 안정적으로 동작합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GYMPT-Advanced-Capstone/GYMPT/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->