### PR TITLE
refactor/[BE-114] 스쿼트 실시간 피드백 표시 및 시작 안내 개선

### DIFF
--- a/frontend/src/app/features/workout/CameraAnalysisPage.tsx
+++ b/frontend/src/app/features/workout/CameraAnalysisPage.tsx
@@ -80,6 +80,7 @@ const TEXT = {
   modelLoading: "AI 자세 모델을 불러오는 중입니다...",
   modelError: "AI 자세 분석을 시작할 수 없습니다.",
   detecting: "랜드마크를 기반으로 자세를 분석 중입니다.",
+  squatGuide: "발은 어깨너비로, 엉덩이를 뒤로 빼며 천천히 앉았다 일어나세요.",
   searching: "화면에서 자세를 찾고 있습니다.",
   calibrationLoading: "초기 범위 데이터를 불러오는 중입니다.",
 } as const;
@@ -238,8 +239,7 @@ export function CameraAnalysisPage() {
       !isPushup
       && currentAnalysis.fullRepCount === 0
       && currentAnalysis.status === "tracking"
-      && currentAnalysis.feedbackMessage
-        ? currentAnalysis.feedbackMessage
+        ? currentAnalysis.feedbackMessage || (isSquat ? TEXT.squatGuide : null)
         : null,
     repEvent: currentAnalysis.lastRepEvent,
   });
@@ -253,7 +253,8 @@ export function CameraAnalysisPage() {
   } else if (poseStatus === "error") {
     noticeMessage = poseErrorMessage ?? TEXT.modelError;
   } else if (hasPoseLandmarks) {
-    noticeMessage = isPushup ? TEXT.detecting : (currentAnalysis.feedbackMessage || TEXT.detecting);
+    const readyGuide = isSquat ? TEXT.squatGuide : TEXT.detecting;
+    noticeMessage = isPushup ? TEXT.detecting : (currentAnalysis.feedbackMessage || readyGuide);
   }
   if (noticeMessageOverride) {
     noticeMessage = noticeMessageOverride;

--- a/frontend/src/app/features/workout/hooks/useSquatAnalysis.ts
+++ b/frontend/src/app/features/workout/hooks/useSquatAnalysis.ts
@@ -281,10 +281,21 @@ export function useSquatAnalysis({
         const nextCount = feedback.fullRepCount ?? prev.fullRepCount;
         const nextStatus = isSquatAnalysisStatus(feedback.status) ? feedback.status : prev.status;
         const nextTimestamp = feedback.timestampMs ?? performance.now();
+        const countIncreased = nextCount > prev.fullRepCount;
+        const shouldShowImmediateFeedback = nextStatus === "insufficient_visibility";
 
         let nextRepSummaries = prev.repSummaries;
         let nextLastRepEvent = prev.lastRepEvent;
+        let nextFeedbackMessage = prev.feedbackMessage;
+
+        if (shouldShowImmediateFeedback) {
+          nextFeedbackMessage = nextMessage;
+        } else if (prev.status === "insufficient_visibility" && nextStatus === "tracking") {
+          nextFeedbackMessage = prev.lastRepEvent?.feedbackMessage ?? "";
+        }
+
         if (feedback.repCompleted && feedback.repSummary) {
+          const representativeMessage = feedback.representativeFeedbackMessage ?? nextMessage;
           nextRepSummaries = [
             ...prev.repSummaries,
             {
@@ -296,19 +307,21 @@ export function useSquatAnalysis({
           ];
           nextLastRepEvent = {
             count: nextCount,
-            feedbackMessage: feedback.representativeFeedbackMessage ?? nextMessage,
+            feedbackMessage: representativeMessage,
             feedbackCode: feedback.representativeFeedbackCode ?? null,
           };
-        } else if (nextCount > prev.fullRepCount) {
+          nextFeedbackMessage = representativeMessage;
+        } else if (countIncreased) {
           nextLastRepEvent = {
             count: nextCount,
             feedbackMessage: nextMessage,
             feedbackCode: feedback.warningCode ?? prev.lastRepEvent?.feedbackCode ?? null,
           };
+          nextFeedbackMessage = nextMessage;
         }
 
         if (
-          nextMessage === prev.feedbackMessage
+          nextFeedbackMessage === prev.feedbackMessage
           && nextCount === prev.fullRepCount
           && nextStatus === prev.status
           && nextRepSummaries === prev.repSummaries
@@ -320,7 +333,7 @@ export function useSquatAnalysis({
           ...prev,
           timestampMs: nextTimestamp,
           status: nextStatus,
-          feedbackMessage: nextMessage,
+          feedbackMessage: nextFeedbackMessage,
           fullRepCount: nextCount,
           repSummaries: nextRepSummaries,
           warningCode: feedback.warningCode ?? prev.warningCode,


### PR DESCRIPTION
## Summary

>- #121 

스쿼트 운동 중 화면 피드백이 매 프레임처럼 자주 바뀌던 문제를 개선했습니다. 자세 피드백은 사용자가 1회 운동을 완료했을 때만 갱신되도록 변경하고, 관절이 화면에 보이지 않는 등의 즉시 안내가 필요한 피드백은 기존처럼 바로 표시되도록 유지했습니다.

또한 스쿼트 시작 전 안내 문구를 “랜드마크를 기반으로 자세를 분석 중입니다.” 대신 간단한 스쿼트 수행 방법으로 변경하고, 해당 문구가 TTS로도 출력되도록 연결했습니다.

## Tasks

- [ ] 스쿼트 자세 피드백이 1회 운동 완료 시점에만 화면에 반영되도록 수정
- [ ] 관절/자세 미인식 피드백은 즉시 화면에 표시되도록 유지
- [ ] 스쿼트 시작 전 간단한 수행 방법 안내 문구 추가
- [ ] 스쿼트 시작 안내 문구가 TTS로 출력되도록 수정



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

스쿼트 운동의 자세 분석 및 실시간 피드백 기능이 개선되었습니다.

* **개선 사항**
  * 스쿼트 운동 중 안내 메시지 기본값 추가로 사용자 지도 개선
  * 카메라 인식 상태에 따른 실시간 자세 피드백 처리 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->